### PR TITLE
Remove blueprint options

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -20,12 +20,6 @@
 			"options": {
 				"activate": true
 			}
-		},
-		{
-			"step": "setSiteOptions",
-			"options": {
-				"gravatar_enhanced_options": "a:4:{s:7:\"version\";s:5:\"0.3.0\";s:6:\"avatar\";a:2:{s:20:\"force_default_avatar\";b:0;s:9:\"force_alt\";b:1;}s:5:\"proxy\";a:2:{s:4:\"type\";s:7:\"private\";s:4:\"time\";i:0;}s:9:\"analytics\";a:1:{s:7:\"enabled\";b:1;}}"
-			}
 		}
 	]
 }


### PR DESCRIPTION
Something isn’t quite right with the options and it causes a crash when saving live. Remove them for now and just use the defaults