### PR TITLE
Fix: Do not display hidden verified accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ dist
 node_modules
 svn
 .phpunit.result.cache
-hovercards.css
-hovercards.js
 build
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An enhanced version of Gravatar for WordPress.
 - Clone this repo to the `wp-content/plugins` directory of a WordPress installation
 - `composer install`
 - `yarn install`
+- `yarn build`
 - Activate plugin
 - Configure plugin from the Settings > Discussion page
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"release-it": "^17.6.0"
 	},
 	"dependencies": {
-		"@gravatar-com/hovercards": "^0.9.0",
+		"@gravatar-com/hovercards": "^0.9.2",
 		"@gravatar-com/quick-editor": "^0.6.0",
 		"js-sha256": "^0.11.0",
 		"lodash.debounce": "^4.0.8"

--- a/src/hovercards/utils.ts
+++ b/src/hovercards/utils.ts
@@ -25,11 +25,12 @@ export function convertJsonToUser( profile: GravatarAPIProfile, avatarUrl: strin
 		location,
 		jobTitle,
 		verifiedAccounts: verifiedAccounts.map(
-			( { url, service_label: label, service_icon: icon, service_type: type } ) => ( {
-				label,
-				icon,
+			( { url, service_label, service_icon, service_type, is_hidden } ) => ( {
 				url,
-				type,
+				label: service_label,
+				icon: service_icon,
+				type: service_type,
+				isHidden: is_hidden,
 			} )
 		),
 	};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,6 +3,7 @@ interface GravatarAPIAccount {
 	service_label: string;
 	service_icon: string;
 	service_type: string;
+	is_hidden: boolean;
 }
 
 interface GravatarAPIProfile {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,10 +1111,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@gravatar-com/hovercards@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.npmjs.org/@gravatar-com/hovercards/-/hovercards-0.9.0.tgz"
-  integrity sha512-sX7ZQO8UPQD46M4/3qw1u9YTzZVsLzwJprmOqdmcmtDs+Yz7/ebRty8z84QUBRu9ChTkYSm7Li3YLKXD8BE3bw==
+"@gravatar-com/hovercards@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.9.2.tgz#4cda4fc9f6b3db57cb48a8c5d3e4a39b9d812cda"
+  integrity sha512-ITP1WwPoRxzT4d+oWkwGxCfRGQiC2xNtndrq9IjAJQvZv09TLqDMit/D7KqhYynVH/GgpJOVfkWvRp1on7C8SA==
 
 "@gravatar-com/quick-editor@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
## Description

- Fix issue: 108930-gh-Automattic/gravatar
- (Extra) Update doc
- (Extra) Update `.gitignore`

## Test Instructions

- Check out this PR
- Follow [this doc](https://github.com/Automattic/gravatar-enhanced/blob/0e7a19a91fa33d836e77d95cc6f634ec99439c53/README.md#development) to install the plugin
- Create a Gravatar profile block, and you won't see the hidden verified accounts, e.g:

| My Accounts | Profile block |
| - | - |
| <img width="406" alt="截圖 2024-09-19 下午3 42 09" src="https://github.com/user-attachments/assets/478679fd-06f2-4f33-b972-77dd193bc734"> | <img width="445" alt="截圖 2024-09-19 下午3 42 21" src="https://github.com/user-attachments/assets/aac58ac7-6893-45fd-aa96-996e0280ca5c"> |

- Go to the WP admin > Users > Yourself, and you won't see the hidden verified accounts, e.g:

| My Accounts | Myself |
| - | - |
| <img width="406" alt="截圖 2024-09-19 下午3 42 09" src="https://github.com/user-attachments/assets/478679fd-06f2-4f33-b972-77dd193bc734"> | <img width="438" alt="截圖 2024-09-19 下午3 47 11" src="https://github.com/user-attachments/assets/3e4b0073-5fc7-460a-96ab-71d7febb0759"> |

