### PR TITLE
Use a single instance of QE

### DIFF
--- a/src/quick-editor/show-quick-editor.ts
+++ b/src/quick-editor/show-quick-editor.ts
@@ -4,6 +4,8 @@ import trackEvent from '../shared/analytics';
 const UPDATE_DELAY = 2000;
 const LOADING_CLASS = 'avatar-loading';
 
+let quickEditor = null;
+
 function updateAvatars() {
 	const images: NodeListOf< HTMLImageElement > = document.querySelectorAll(
 		'.gravatar-hovercard__avatar, #wp-admin-bar-my-account .avatar'
@@ -27,20 +29,22 @@ function updateAvatars() {
 }
 
 export default function showQuickEditor( email: string, locale: string, scope: Scope, updateProfile: () => void ) {
-	const quickEditor = new GravatarQuickEditorCore( {
-		email,
-		scope,
-		locale,
-		onProfileUpdated: ( type ) => {
-			if ( type === 'avatar_updated' ) {
-				trackEvent( 'gravatar_enhanced_qe_avatar_updated' );
-				updateAvatars();
-			} else if ( type === 'profile_updated' ) {
-				trackEvent( 'gravatar_enhanced_qe_profile_updated' );
-				updateProfile();
-			}
-		},
-	} );
+	if ( ! quickEditor ) {
+		quickEditor = new GravatarQuickEditorCore( {
+			email,
+			scope,
+			locale,
+			onProfileUpdated: ( type ) => {
+				if ( type === 'avatar_updated' ) {
+					trackEvent( 'gravatar_enhanced_qe_avatar_updated' );
+					updateAvatars();
+				} else if ( type === 'profile_updated' ) {
+					trackEvent( 'gravatar_enhanced_qe_profile_updated' );
+					updateProfile();
+				}
+			},
+		} );
+	}
 
 	quickEditor.open();
 }


### PR DESCRIPTION
Reuse the QE instance so that clicking the button multiple times doesn’t create multiple instances

Fixes #36

# Test instructions

- Go to `/wp-admin/profile.php` page
- Click 'edit profile' on the hovercard
- Move QE window to the side and click 'edit profile' again. Confirm another QE window is not opened