### PR TITLE
Add commenting enhancements

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -121,6 +121,8 @@ class Plugin {
 		$this->wc_admin_customers = new Woocommerce\AdminCustomers();
 		$this->wc_my_account = new Woocommerce\MyAccount();
 		$this->oembed = new OEmbed\OEmbed();
+		$this->comments = new Comments\Comments( new Comments\Preferences( $this->auto_options ) );
+
 		// Collect all modules and filter them based on the whitelist if available.
 		$this->modules = [
 			'email' => $this->email,

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/patterns/class-patterns.php';
 require_once __DIR__ . '/woocommerce/class-admin-customers.php';
 require_once __DIR__ . '/woocommerce/class-my-account.php';
 require_once __DIR__ . '/oembed/class-oembed.php';
+require_once __DIR__ . '/comments/class-comments.php';
 
 class Plugin {
 	const OPTION_NAME_AUTO = 'gravatar_enhanced_options';
@@ -91,6 +92,11 @@ class Plugin {
 	private $oembed;
 
 	/**
+	 * @var Comments\Comments
+	 */
+	private $comments;
+
+	/**
 	 * @var Module[]
 	 */
 	private $modules;
@@ -128,6 +134,7 @@ class Plugin {
 			'wc_admin_customers' => $this->wc_admin_customers,
 			'wc_my_account' => $this->wc_my_account,
 			'oembed' => $this->oembed,
+			'comments' => $this->comments,
 		];
 		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null );
 		if ( is_array( $modules_whitelist ) ) {

--- a/classes/comments/class-comments-options.php
+++ b/classes/comments/class-comments-options.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\Comments;
+
+/**
+ * @psalm-type CommentsOptionsArray = array{
+ *   enabled: bool,
+ * }
+ */
+class Options {
+	/** @var bool */
+	public $enabled;
+
+	/**
+	 * @param bool $enabled
+	 */
+	public function __construct( $enabled ) {
+		$this->enabled = $enabled;
+	}
+
+	/**
+	 * @return CommentsOptionsArray
+	 */
+	public function to_array() {
+		return [
+			'enabled' => $this->enabled,
+		];
+	}
+
+	/**
+	 * @param CommentsOptionsArray $options
+	 * @return Options
+	 */
+	public static function from_array( $options ) {
+		return new Options( $options['enabled'] );
+	}
+}

--- a/classes/comments/class-comments-preferences.php
+++ b/classes/comments/class-comments-preferences.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Automattic\Gravatar\GravatarEnhanced\Analytics;
+namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type AnalyticsOptionsArray from Options
+ * @psalm-import-type CommentsOptionsArray from Options
  * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
-	const OPTION_NAME = 'analytics';
+	const OPTION_NAME = 'comments';
 
 	/**
 	 * @var Options
@@ -21,7 +21,7 @@ class Preferences {
 	 * @param Options | null $new_options
 	 */
 	public function __construct( $saved_options, $new_options = null ) {
-		/** @var AnalyticsOptionsArray */
+		/** @var CommentsOptionsArray */
 		$options = array_merge(
 			$this->get_default_options(),
 			$saved_options->get_group( self::OPTION_NAME ),
@@ -32,11 +32,11 @@ class Preferences {
 	}
 
 	/**
-	 * @return AnalyticsOptionsArray
+	 * @return CommentsOptionsArray
 	 */
 	private function get_default_options() {
 		return [
-			'enabled' => false,
+			'enabled' => true,
 		];
 	}
 
@@ -48,7 +48,7 @@ class Preferences {
 	}
 
 	/**
-	 * @return array<string,AnalyticsOptionsArray>
+	 * @return array<string,CommentsOptionsArray>
 	 */
 	public function get_as_preferences() {
 		return [

--- a/classes/comments/class-comments-preferences.php
+++ b/classes/comments/class-comments-preferences.php
@@ -36,7 +36,7 @@ class Preferences {
 	 */
 	private function get_default_options() {
 		return [
-			'enabled' => true,
+			'enabled' => false,
 		];
 	}
 

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\Comments;
+
+require_once __DIR__ . '/class-comments-options.php';
+require_once __DIR__ . '/class-comments-preferences.php';
+
+class Comments {
+	const OPTION_COMMENTS = 'gravatar_comments';
+
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @param Preferences $preferences
+	 */
+	public function __construct( $preferences ) {
+		$this->options = $preferences->get_options();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function init() {
+		// Are we enabled?
+		if ( ! $this->options->enabled ) {
+			return;
+		}
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
+		add_action( 'comment_form_field_email', [ $this, 'comment_form_field_email' ] );
+		add_action( 'comment_form_logged_in', [ $this, 'comment_form_logged_in' ] );
+		add_filter( 'comment_form_fields', [ $this, 'comment_form_fields' ] );
+	}
+
+	/**
+	 * Rearrange the order so the email comes before name
+	 *
+	 * @param array<string, string> $fields
+	 * @return array<string, string>
+	 */
+	public function comment_form_fields( array $fields ): array {
+		if ( isset( $fields['email'] ) && isset( $fields['author'] ) ) {
+			$email_field = $fields['email'];
+			unset( $fields['email'] );
+			$reordered_fields = [];
+
+			foreach ( $fields as $key => $value ) {
+				if ( $key === 'author' ) {
+					$reordered_fields['email'] = $email_field;
+				}
+				$reordered_fields[ $key ] = $value;
+			}
+
+			return $reordered_fields;
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Enqueue a JS file.
+	 *
+	 * @return void
+	 */
+	public function wp_enqueue_scripts() {
+		// Is this a commentable post?
+		if ( ! is_singular() || ! comments_open() ) {
+			return;
+		}
+
+		$asset_file = dirname( GRAVATAR_ENHANCED_PLUGIN_FILE ) . '/build/comments.asset.php';
+		$assets = file_exists( $asset_file ) ? require $asset_file : [ 'dependencies' => [], 'version' => time() ];
+
+		wp_enqueue_script( 'gravatar-enhanced-comments', plugins_url( 'build/comments.js', GRAVATAR_ENHANCED_PLUGIN_FILE ), $assets['dependencies'], $assets['version'], true );
+
+		wp_register_style( 'gravatar-enhanced-comments', plugins_url( 'build/style-comments.css', GRAVATAR_ENHANCED_PLUGIN_FILE ), [], $assets['version'] );
+		wp_enqueue_style( 'gravatar-enhanced-comments' );
+
+		$comment_data = [
+			'locale' => 'en',
+		];
+
+		// Check if user is logged in
+		if ( is_user_logged_in() ) {
+			$current_user = wp_get_current_user();
+
+			$current_user_locale = get_user_locale( $current_user );
+			$current_user_locale = (string) preg_replace( '/_.*$/', '', $current_user_locale );
+			$comment_data['email'] = $current_user->user_email;
+			$comment_data['locale'] = 'en' === $current_user_locale ? '' : $current_user_locale;
+		}
+
+		wp_localize_script(
+			'gravatar-enhanced-comments',
+			'gravatarEnhancedComments',
+			$comment_data
+		);
+	}
+
+	/**
+	 * Output the Gravatar-enhanced comments form field for logged-out user.
+	 *
+	 * @param string $field
+	 * @return void
+	 */
+	public function comment_form_field_email( $field ) {
+		echo $field;
+
+		?>
+		<div class="gravatar-enhanced-comments gravatar-enhanced-comments--hidden">
+			<img src="" alt="<?php echo esc_attr( __( 'Gravatar profile', 'gravatar-enhanced' ) ); ?>" />
+
+			<button type="button"><?php echo esc_html( __( 'Edit', 'gravatar-enhanced' ) ); ?></button>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Output the Gravatar-enhanced comments form field for logged-in user.
+	 *
+	 * @param string $text
+	 * @return void
+	 */
+	public function comment_form_logged_in( $text ) {
+		echo $text;
+
+		?>
+		<div class="gravatar-enhanced-comments">
+			<?php echo get_avatar( wp_get_current_user()->user_email, 128 ); ?>
+
+			<button type="button"><?php echo esc_html( __( 'Edit', 'gravatar-enhanced' ) ); ?></button>
+		</div>
+		<?php
+	}
+}

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -31,7 +31,6 @@ class Comments {
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
 		add_action( 'comment_form_field_email', [ $this, 'comment_form_field_email' ] );
-		add_action( 'comment_form_logged_in', [ $this, 'comment_form_logged_in' ] );
 		add_filter( 'comment_form_fields', [ $this, 'comment_form_fields' ] );
 	}
 
@@ -121,23 +120,5 @@ class Comments {
 		$field = preg_replace( '@</(\w+)>$@', $grav_field . '</$1>', $field );
 
 		echo $field;
-	}
-
-	/**
-	 * Output the Gravatar-enhanced comments form field for logged-in user.
-	 *
-	 * @param string $text
-	 * @return void
-	 */
-	public function comment_form_logged_in( $text ) {
-		echo $text;
-
-		?>
-		<div class="gravatar-enhanced-comments">
-			<?php echo get_avatar( wp_get_current_user()->user_email, 128 ); ?>
-
-			<button type="button"><?php echo esc_html( __( 'Edit', 'gravatar-enhanced' ) ); ?></button>
-		</div>
-		<?php
 	}
 }

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -76,6 +76,13 @@ class Comments {
 
 		wp_enqueue_script( 'gravatar-enhanced-comments', plugins_url( 'build/comments.js', GRAVATAR_ENHANCED_PLUGIN_FILE ), $assets['dependencies'], $assets['version'], true );
 
+		$theme = wp_get_theme();
+		$override_file = __DIR__ . '/theme-override/' . $theme->get_template() . '.css';
+		if ( file_exists( $override_file ) ) {
+			wp_register_style( 'gravatar-enhanced-comments-override', plugins_url( 'classes/comments/theme-override/' . $theme->get_template() . '.css', GRAVATAR_ENHANCED_PLUGIN_FILE ), [], $assets['version'] );
+			wp_enqueue_style( 'gravatar-enhanced-comments-override' );
+		}
+
 		wp_register_style( 'gravatar-enhanced-comments', plugins_url( 'build/style-comments.css', GRAVATAR_ENHANCED_PLUGIN_FILE ), [], $assets['version'] );
 		wp_enqueue_style( 'gravatar-enhanced-comments' );
 
@@ -107,15 +114,13 @@ class Comments {
 	 * @return void
 	 */
 	public function comment_form_field_email( $field ) {
+		$grav_field = '<span class="gravatar-enhanced-profile">';
+		$grav_field .= '<img src="" alt="' . esc_attr( __( 'Gravatar profile', 'gravatar-enhanced' ) ) . '" />';
+		$grav_field .= '</span>';
+
+		$field = preg_replace( '@</(\w+)>$@', $grav_field . '</$1>', $field );
+
 		echo $field;
-
-		?>
-		<div class="gravatar-enhanced-comments gravatar-enhanced-comments--hidden">
-			<img src="" alt="<?php echo esc_attr( __( 'Gravatar profile', 'gravatar-enhanced' ) ); ?>" />
-
-			<button type="button"><?php echo esc_html( __( 'Edit', 'gravatar-enhanced' ) ); ?></button>
-		</div>
-		<?php
 	}
 
 	/**

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -2,10 +2,12 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
 require_once __DIR__ . '/class-comments-options.php';
 require_once __DIR__ . '/class-comments-preferences.php';
 
-class Comments {
+class Comments implements Module {
 	const OPTION_COMMENTS = 'gravatar_comments';
 
 	/**
@@ -32,6 +34,12 @@ class Comments {
 		add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
 		add_action( 'comment_form_field_email', [ $this, 'comment_form_field_email' ] );
 		add_filter( 'comment_form_fields', [ $this, 'comment_form_fields' ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {
 	}
 
 	/**

--- a/classes/comments/theme-override/twentynineteen.css
+++ b/classes/comments/theme-override/twentynineteen.css
@@ -1,0 +1,6 @@
+@media only screen and (min-width: 768px) {
+	.comment-form .comment-form-email {
+		margin-left: 0px !important;
+		margin-right: 1rem;
+	}
+}

--- a/classes/comments/theme-override/twentytwenty.css
+++ b/classes/comments/theme-override/twentytwenty.css
@@ -1,0 +1,6 @@
+@media (min-width: 700px) {
+	.comment-respond .comment-form-email {
+		margin-right: 2rem;
+		margin-left: 0px !important;
+	}
+}

--- a/classes/comments/theme-override/twentytwentyone.css
+++ b/classes/comments/theme-override/twentytwentyone.css
@@ -1,0 +1,9 @@
+@media only screen and (min-width: 482px) {
+	.comment-form > p.comment-form-author {
+		margin-right: 0px !important;
+	}
+
+	.comment-form > p.comment-form-email {
+		margin-right: calc(1.5* var(--global--spacing-horizontal));
+	}
+}

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -293,6 +293,19 @@ class DiscussionsPage {
 	}
 
 	/**
+	 * @return Comments\Preferences
+	 */
+	private function get_comment_preferences() {
+		$options = [
+			'enabled' => isset( $_POST['gravatar_comments'] ),
+		];
+
+		$new_options = Comments\Options::from_array( $options );
+
+		return new Comments\Preferences( $this->auto_options, $new_options );
+	}
+
+	/**
 	 * @return Avatar\Preferences
 	 */
 	private function get_avatar_preferences() {

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -274,14 +274,22 @@ class DiscussionsPage {
 			$avatar_preferences = $this->get_avatar_preferences();
 			$this->auto_options->update( $avatar_preferences );
 		}
+
 		if ( in_array( 'proxy', $this->enabled_modules, true ) ) {
 			$proxy_preferences = $this->get_proxy_preferences();
 			$this->auto_options->update( $proxy_preferences );
 		}
+
 		if ( in_array( 'analytics', $this->enabled_modules, true ) ) {
 			$analytics_preferences = $this->get_analytics_preferences();
 			$this->auto_options->update( $analytics_preferences );
 		}
+
+		if ( in_array( 'comments', $this->enabled_modules, true ) ) {
+			$comment_preferences = $this->get_comment_preferences();
+			$this->auto_options->update( $comment_preferences );
+		}
+
 		$this->auto_options->save();
 
 		// Handle lazy options.

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -7,6 +7,7 @@ use Automattic\Gravatar\GravatarEnhanced\Proxy;
 use Automattic\Gravatar\GravatarEnhanced\Email;
 use Automattic\Gravatar\GravatarEnhanced\Avatar;
 use Automattic\Gravatar\GravatarEnhanced\Analytics;
+use Automattic\Gravatar\GravatarEnhanced\Comments;
 
 require_once __DIR__ . '/class-saved-options.php';
 require_once __DIR__ . '/class-migrate.php';
@@ -95,6 +96,16 @@ class DiscussionsPage {
 				'avatars'
 			);
 		}
+
+		if ( in_array( 'comments', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'comment-options',
+				__( 'Gravatar Comments', 'gravatar-enhanced' ),
+				[ $this, 'display_comment_settings' ],
+				'discussion',
+				'avatars'
+			);
+	}
 	}
 
 	/**
@@ -228,6 +239,23 @@ class DiscussionsPage {
 				<?php esc_html_e( 'Help us make Gravatar better by allowing us to collect anonymous usage tracking of the features used.', 'gravatar-enhanced' ); ?>
 
 				<?php _e( 'You can find details about this on the <a href="https://support.gravatar.com/gravatar-enhanced-wordpress-plugin/">support page</a>.', 'gravatar-enhanced' ); ?>
+			</label>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * @return void
+	 */
+	public function display_comment_settings() {
+		$preferences = new Comments\Preferences( $this->auto_options );
+		$comments = $preferences->get_options();
+		?>
+		<fieldset>
+			<label for="gravatar_comments">
+				<input type="checkbox" id="gravatar_comments" name="gravatar_comments" <?php checked( $comments->enabled ); ?> />
+
+				<?php esc_html_e( 'Show Gravatar in the comment form.', 'gravatar-enhanced' ); ?>
 			</label>
 		</fieldset>
 		<?php

--- a/classes/options/class-saved-options.php
+++ b/classes/options/class-saved-options.php
@@ -6,12 +6,14 @@ use Automattic\Gravatar\GravatarEnhanced\Avatar;
 use Automattic\Gravatar\GravatarEnhanced\Proxy;
 use Automattic\Gravatar\GravatarEnhanced\Analytics;
 use Automattic\Gravatar\GravatarEnhanced\Email;
+use Automattic\Gravatar\GravatarEnhanced\Comments;
 
 /**
  * @psalm-import-type AvatarOptionsArray from Avatar\Options
  * @psalm-import-type ProxyOptionsArray from Proxy\Options
  * @psalm-import-type AnalyticsOptionsArray from Analytics\Options
  * @psalm-import-type EmailOptionsArray from Email\Options
+ * @psalm-import-type CommentsOptionsArray from Comments\Options
  *
  * @psalm-type OptionsArray = array{
  *   avatar?: AvatarOptionsArray,
@@ -19,6 +21,7 @@ use Automattic\Gravatar\GravatarEnhanced\Email;
  *   analytics?: AnalyticsOptionsArray,
  *   email?: EmailOptionsArray,
  *   version?: string,
+ *   comments?: CommentsOptionsArray,
  * }
  */
 class SavedOptions {

--- a/classes/options/class-saved-options.php
+++ b/classes/options/class-saved-options.php
@@ -14,6 +14,7 @@ use Automattic\Gravatar\GravatarEnhanced\Comments;
  * @psalm-import-type AnalyticsOptionsArray from Analytics\Options
  * @psalm-import-type EmailOptionsArray from Email\Options
  * @psalm-import-type CommentsOptionsArray from Comments\Options
+ * @psalm-type Preferences Comments\Preferences | Avatar\Preferences | Proxy\Preferences | Email\Preferences | Analytics\Preferences
  *
  * @psalm-type OptionsArray = array{
  *   avatar?: AvatarOptionsArray,
@@ -86,7 +87,7 @@ class SavedOptions {
 	/**
 	 * Update the options. We only save the difference compared to the defaults.
 	 *
-	 * @param Avatar\Preferences | Proxy\Preferences | Email\Preferences | Analytics\Preferences $preferences
+	 * @param Preferences $preferences
 	 * @return void
 	 */
 	public function update( $preferences ) {

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
 	"devDependencies": {
 		"@types/wordpress__block-editor": "^11.5.16",
 		"@types/wordpress__blocks": "^12.5.17",
-		"@wordpress/eslint-plugin": "^22.4.0",
-		"@wordpress/scripts": "^30.11.0",
+		"@wordpress/eslint-plugin": "^22.5.0",
+		"@wordpress/scripts": "^30.12.0",
 		"npm-check-updates": "^17.1.15",
 		"release-it": "^18.1.2",
-		"typescript": "^5.7.3"
+		"typescript": "^5.8.2"
 	},
 	"dependencies": {
-		"@gravatar-com/hovercards": "^0.10.5",
+		"@gravatar-com/hovercards": "^0.10.6",
 		"@gravatar-com/quick-editor": "^0.6.0",
-		"@wordpress/editor": "^14.18.0",
-		"@wordpress/url": "^4.18.0",
+		"@wordpress/editor": "^14.19.0",
+		"@wordpress/url": "^4.19.0",
 		"clsx": "^2.1.1",
 		"js-sha256": "^0.11.0",
 		"lodash.debounce": "^4.0.8"

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -1,0 +1,119 @@
+import { sha256 } from 'js-sha256';
+import showQuickEditor from '../shared/show-quick-editor';
+import { Hovercards } from '@gravatar-com/hovercards';
+import './style.scss';
+
+const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
+const GRAVATAR_CONTAINER = '.gravatar-enhanced-comments';
+const COMMENT_EMAIL_FIELD = '#email';
+const INPUT_TIMEOUT = 1000;
+
+const hovercards = new Hovercards();
+
+function toggleLoading( isLoading ) {
+	const author = document.getElementById( 'author' ) as HTMLInputElement;
+	const url = document.getElementById( 'url' ) as HTMLInputElement;
+	const email = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
+
+	email?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
+	author?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
+	url?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
+}
+
+async function fetchUserProfile( email ) {
+	const hash = sha256( email.trim().toLowerCase() );
+
+	try {
+		// Get profile data
+		const response = await fetch( `${ BASE_API_URL }/${ hash }?source=hovercard` );
+		if ( ! response.ok ) {
+			return null;
+		}
+
+		return await response.json();
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( error );
+	}
+
+	return null;
+}
+
+function suggestProfile( profile ) {
+	const author = document.getElementById( 'author' ) as HTMLInputElement;
+	const url = document.getElementById( 'url' ) as HTMLInputElement;
+
+	if ( author && author.value === '' ) {
+		author.value = profile.display_name;
+	}
+
+	if ( url && url.value === '' ) {
+		url.value = profile.profile_url;
+	}
+}
+
+function showProfile( profile ) {
+	const gravatarProfile = document.querySelector( GRAVATAR_CONTAINER );
+	const gravatarImg = document.querySelector( GRAVATAR_CONTAINER + ' img' ) as HTMLImageElement;
+
+	if ( ! gravatarProfile || ! gravatarImg ) {
+		return;
+	}
+
+	gravatarImg.src = profile.avatar_url;
+	gravatarProfile.classList.remove( 'gravatar-enhanced-comments--hidden' );
+
+	// Hook up to hovercard
+	hovercards.attach( gravatarImg );
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const email = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
+	const qeButton = document.querySelector( GRAVATAR_CONTAINER + ' button' );
+	let lastRequestEmail = '';
+	let debounceTimeout: NodeJS.Timeout;
+
+	const loadProfile = async ( event ) => {
+		const emailValue = ( event.target as HTMLInputElement ).value;
+		if ( emailValue === lastRequestEmail ) {
+			return;
+		}
+
+		toggleLoading( true );
+
+		const profile = await fetchUserProfile( emailValue );
+
+		toggleLoading( false );
+
+		lastRequestEmail = emailValue;
+
+		if ( profile ) {
+			suggestProfile( profile );
+			showProfile( profile );
+		} else {
+			showProfile( {
+				display_name: '',
+				profile_url: '',
+				avatar_url: 'https://gravatar.com/avatar/' + sha256( emailValue.trim().toLowerCase() ),
+			} );
+		}
+	};
+
+	email?.addEventListener( 'blur', loadProfile );
+	email?.addEventListener( 'blur', loadProfile );
+
+	email?.addEventListener( 'input', ( ev ) => {
+		clearTimeout( debounceTimeout );
+		debounceTimeout = setTimeout( () => loadProfile( ev ), INPUT_TIMEOUT );
+	} );
+
+	qeButton?.addEventListener( 'click', () =>
+		showQuickEditor(
+			email?.value || gravatarEnhancedComments?.email || '',
+			gravatarEnhancedComments?.locale || 'en',
+			[ 'avatars' ],
+			GRAVATAR_CONTAINER + ' img',
+			() => {}
+		)
+	);
+} );

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -101,7 +101,7 @@ function adjustGravatarPosition() {
 	emailField.style.paddingLeft = Math.round( height + padding * 1.3 ) + 'px';
 }
 
-function showProfile( profile ) {
+function showProfile( profile, isShowingEditor ) {
 	const gravatarImg = document.querySelector( GRAVATAR_CONTAINER + ' img' ) as HTMLImageElement;
 	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
 
@@ -115,7 +115,11 @@ function showProfile( profile ) {
 	adjustGravatarPosition();
 
 	// Hook up to hovercard
-	hovercards.attach( gravatarImg );
+	hovercards.attach( gravatarImg, {
+		onCanShowHovercard: () => {
+			return ! isShowingEditor();
+		},
+	} );
 }
 
 document.addEventListener( 'DOMContentLoaded', () => {
@@ -124,6 +128,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	let lastRequestEmail = '';
 	let debounceProfileTimeout: NodeJS.Timeout;
 	let debounceResizeTimeout: NodeJS.Timeout;
+	let isShowingEditor = false;
 
 	const loadProfile = async ( event ) => {
 		clearTimeout( debounceProfileTimeout );
@@ -149,13 +154,16 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 		if ( profile ) {
 			suggestProfile( profile );
-			showProfile( profile );
+			showProfile( profile, () => isShowingEditor );
 		} else {
-			showProfile( {
-				display_name: '',
-				profile_url: '',
-				avatar_url: 'https://gravatar.com/avatar/' + sha256( emailValue.trim().toLowerCase() ),
-			} );
+			showProfile(
+				{
+					display_name: '',
+					profile_url: '',
+					avatar_url: 'https://gravatar.com/avatar/' + sha256( emailValue.trim().toLowerCase() ),
+				},
+				() => isShowingEditor
+			);
 		}
 	};
 
@@ -166,15 +174,19 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	} );
 
 	// Hook up the image to the QE
-	qeButton?.addEventListener( 'click', () =>
+	qeButton?.addEventListener( 'click', () => {
+		isShowingEditor = true;
+
 		showQuickEditor(
 			email?.value || gravatarEnhancedComments?.email || '',
 			gravatarEnhancedComments?.locale || 'en',
 			[ 'avatars' ],
 			GRAVATAR_CONTAINER + ' img',
-			() => {}
-		)
-	);
+			() => {
+				isShowingEditor = false;
+			}
+		);
+	} );
 
 	// Reposition the avatar on resize - it can get slightly out of place
 	window.addEventListener( 'resize', () => {

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -4,11 +4,17 @@ import { Hovercards } from '@gravatar-com/hovercards';
 import './style.scss';
 
 const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
-const GRAVATAR_CONTAINER = '.gravatar-enhanced-comments';
+const GRAVATAR_CONTAINER = '.gravatar-enhanced-profile';
 const COMMENT_EMAIL_FIELD = '#email';
 const INPUT_TIMEOUT = 1000;
+const DEBOUNCE_TIMEOUT = 250;
 
 const hovercards = new Hovercards();
+
+function isEmail( email ) {
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+	return emailRegex.test( email );
+}
 
 function toggleLoading( isLoading ) {
 	const author = document.getElementById( 'author' ) as HTMLInputElement;
@@ -52,16 +58,61 @@ function suggestProfile( profile ) {
 	}
 }
 
-function showProfile( profile ) {
-	const gravatarProfile = document.querySelector( GRAVATAR_CONTAINER );
-	const gravatarImg = document.querySelector( GRAVATAR_CONTAINER + ' img' ) as HTMLImageElement;
+function hideProfile() {
+	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
+	const emailField = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
 
-	if ( ! gravatarProfile || ! gravatarImg ) {
+	if ( ! emailField || ! emailContainer ) {
+		return;
+	}
+
+	emailContainer.classList.remove( 'gravatar-enhanced-comments' );
+	emailField.style.paddingLeft = '';
+}
+
+function adjustGravatarPosition() {
+	const gravatarProfile = document.querySelector( GRAVATAR_CONTAINER ) as HTMLElement;
+	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
+	const emailField = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
+
+	if ( ! gravatarProfile || ! emailField || ! emailContainer ) {
+		return;
+	}
+
+	// Measure the email field
+	const computedStyle = getComputedStyle( emailField );
+	const padding = parseInt( computedStyle.paddingTop, 10 ) + parseInt( computedStyle.borderTopWidth, 10 );
+	const emailFieldRect = emailField.getBoundingClientRect();
+	const emailContainerRect = emailContainer.getBoundingClientRect();
+	const topRectOffset = emailFieldRect.top - emailContainerRect.top;
+	const leftRectOffset = emailFieldRect.left - emailContainerRect.left;
+	const height = Math.round( emailFieldRect.height * 0.8 );
+	const heightDifference = emailFieldRect.height - height;
+	const leftOffset = Math.round( leftRectOffset + padding / 2 ) + parseInt( computedStyle.borderLeftWidth );
+	const topOffset = Math.round( topRectOffset + heightDifference / 2 );
+
+	// Position the Gravatar inside the text field
+	gravatarProfile.style.height = height + 'px';
+	gravatarProfile.style.width = height + 'px';
+	gravatarProfile.style.top = topOffset + 'px';
+	gravatarProfile.style.left = leftOffset + 'px';
+
+	// Move the text up to allow the Gravatar to fit
+	emailField.style.paddingLeft = Math.round( height + padding * 1.3 ) + 'px';
+}
+
+function showProfile( profile ) {
+	const gravatarImg = document.querySelector( GRAVATAR_CONTAINER + ' img' ) as HTMLImageElement;
+	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
+
+	if ( ! gravatarImg || ! emailContainer ) {
 		return;
 	}
 
 	gravatarImg.src = profile.avatar_url;
-	gravatarProfile.classList.remove( 'gravatar-enhanced-comments--hidden' );
+	emailContainer.classList.add( 'gravatar-enhanced-comments' );
+
+	adjustGravatarPosition();
 
 	// Hook up to hovercard
 	hovercards.attach( gravatarImg );
@@ -69,13 +120,22 @@ function showProfile( profile ) {
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	const email = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
-	const qeButton = document.querySelector( GRAVATAR_CONTAINER + ' button' );
+	const qeButton = document.querySelector( GRAVATAR_CONTAINER + ' img' );
 	let lastRequestEmail = '';
-	let debounceTimeout: NodeJS.Timeout;
+	let debounceProfileTimeout: NodeJS.Timeout;
+	let debounceResizeTimeout: NodeJS.Timeout;
 
 	const loadProfile = async ( event ) => {
+		clearTimeout( debounceProfileTimeout );
+
 		const emailValue = ( event.target as HTMLInputElement ).value;
 		if ( emailValue === lastRequestEmail ) {
+			return;
+		}
+
+		if ( ! isEmail( emailValue ) ) {
+			lastRequestEmail = '';
+			hideProfile();
 			return;
 		}
 
@@ -100,13 +160,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	};
 
 	email?.addEventListener( 'blur', loadProfile );
-	email?.addEventListener( 'blur', loadProfile );
-
 	email?.addEventListener( 'input', ( ev ) => {
-		clearTimeout( debounceTimeout );
-		debounceTimeout = setTimeout( () => loadProfile( ev ), INPUT_TIMEOUT );
+		clearTimeout( debounceProfileTimeout );
+		debounceProfileTimeout = setTimeout( () => loadProfile( ev ), INPUT_TIMEOUT );
 	} );
 
+	// Hook up the image to the QE
 	qeButton?.addEventListener( 'click', () =>
 		showQuickEditor(
 			email?.value || gravatarEnhancedComments?.email || '',
@@ -116,4 +175,15 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			() => {}
 		)
 	);
+
+	// Reposition the avatar on resize - it can get slightly out of place
+	window.addEventListener( 'resize', () => {
+		clearTimeout( debounceResizeTimeout );
+
+		debounceProfileTimeout = setTimeout( () => {
+			if ( lastRequestEmail ) {
+				adjustGravatarPosition();
+			}
+		}, DEBOUNCE_TIMEOUT );
+	} );
 } );

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -5,9 +5,9 @@ import './style.scss';
 
 const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
 const GRAVATAR_CONTAINER = '.gravatar-enhanced-profile';
+const COMMENT_EMAIL_WRAPPER = '.comment-form-email';
 const COMMENT_EMAIL_FIELD = '#email';
 const INPUT_TIMEOUT = 1000;
-const DEBOUNCE_TIMEOUT = 250;
 
 const hovercards = new Hovercards();
 
@@ -62,7 +62,7 @@ function hideProfile() {
 }
 
 function adjustGravatarPosition() {
-	const gravatarProfile = document.querySelector( GRAVATAR_CONTAINER ) as HTMLElement;
+	const gravatarProfile = document.querySelector( GRAVATAR_CONTAINER ) as HTMLSpanElement;
 	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
 	const emailField = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
 
@@ -96,7 +96,7 @@ function adjustGravatarPosition() {
 
 function showProfile( profile, isShowingEditor ) {
 	const gravatarImg = document.querySelector( GRAVATAR_CONTAINER + ' img' ) as HTMLImageElement;
-	const emailContainer = document.querySelector( '.comment-form-email' ) as HTMLInputElement;
+	const emailContainer = document.querySelector( COMMENT_EMAIL_WRAPPER ) as HTMLInputElement;
 
 	if ( ! gravatarImg || ! emailContainer ) {
 		return;
@@ -120,7 +120,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const qeButton = document.querySelector( GRAVATAR_CONTAINER + ' img' );
 	let lastRequestEmail = '';
 	let debounceProfileTimeout: NodeJS.Timeout;
-	let debounceResizeTimeout: NodeJS.Timeout;
 	let isShowingEditor = false;
 
 	const loadProfile = async ( event ) => {
@@ -178,13 +177,16 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	} );
 
 	// Reposition the avatar on resize - it can get slightly out of place
-	window.addEventListener( 'resize', () => {
-		clearTimeout( debounceResizeTimeout );
-
-		debounceProfileTimeout = setTimeout( () => {
-			if ( lastRequestEmail ) {
+	const resizeObserver = new ResizeObserver( () => {
+		if ( lastRequestEmail ) {
+			window.requestAnimationFrame( () => {
 				adjustGravatarPosition();
-			}
-		}, DEBOUNCE_TIMEOUT );
+			} );
+		}
 	} );
+
+	const emailContainer = document.querySelector( COMMENT_EMAIL_WRAPPER ) as HTMLInputElement;
+	if ( emailContainer ) {
+		resizeObserver.observe( emailContainer );
+	}
 } );

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -86,10 +86,12 @@ function adjustGravatarPosition() {
 	const emailContainerRect = emailContainer.getBoundingClientRect();
 	const topRectOffset = emailFieldRect.top - emailContainerRect.top;
 	const leftRectOffset = emailFieldRect.left - emailContainerRect.left;
-	const height = Math.round( emailFieldRect.height * 0.8 );
-	const heightDifference = emailFieldRect.height - height;
-	const leftOffset = Math.round( leftRectOffset + padding / 2 ) + parseInt( computedStyle.borderLeftWidth );
-	const topOffset = Math.round( topRectOffset + heightDifference / 2 );
+	const height = parseFloat( ( emailFieldRect.height * 0.8 ).toFixed( 1 ) );
+	const heightDifference = parseFloat( ( emailFieldRect.height - height ).toFixed( 1 ) );
+	const leftOffset = parseFloat(
+		( leftRectOffset + padding / 2 + parseInt( computedStyle.borderLeftWidth ) ).toFixed( 1 )
+	);
+	const topOffset = parseFloat( ( topRectOffset + heightDifference / 2 ).toFixed( 1 ) );
 
 	// Position the Gravatar inside the text field
 	gravatarProfile.style.height = height + 'px';
@@ -98,7 +100,7 @@ function adjustGravatarPosition() {
 	gravatarProfile.style.left = leftOffset + 'px';
 
 	// Move the text up to allow the Gravatar to fit
-	emailField.style.paddingLeft = Math.round( height + padding * 1.3 ) + 'px';
+	emailField.style.paddingLeft = parseFloat( ( height + padding * 1.3 ).toFixed( 1 ) ) + 'px';
 }
 
 function showProfile( profile, isShowingEditor ) {

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -16,16 +16,6 @@ function isEmail( email ) {
 	return emailRegex.test( email );
 }
 
-function toggleLoading( isLoading ) {
-	const author = document.getElementById( 'author' ) as HTMLInputElement;
-	const url = document.getElementById( 'url' ) as HTMLInputElement;
-	const email = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;
-
-	email?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
-	author?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
-	url?.classList.toggle( 'gravatar-enhanced-is-loading', isLoading );
-}
-
 async function fetchUserProfile( email ) {
 	const hash = sha256( email.trim().toLowerCase() );
 
@@ -146,11 +136,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			return;
 		}
 
-		toggleLoading( true );
-
 		const profile = await fetchUserProfile( emailValue );
-
-		toggleLoading( false );
 
 		lastRequestEmail = emailValue;
 

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -38,13 +38,14 @@ async function fetchUserProfile( email ) {
 function suggestProfile( profile ) {
 	const author = document.getElementById( 'author' ) as HTMLInputElement;
 	const url = document.getElementById( 'url' ) as HTMLInputElement;
+	const firstVerified = profile.verified_accounts.length > 0 ? profile.verified_accounts[ 0 ] : null;
 
 	if ( author && author.value === '' ) {
 		author.value = profile.display_name;
 	}
 
-	if ( url && url.value === '' ) {
-		url.value = profile.profile_url;
+	if ( url && url.value === '' && firstVerified ) {
+		url.value = firstVerified.url;
 	}
 }
 

--- a/src/comments/style.scss
+++ b/src/comments/style.scss
@@ -1,0 +1,40 @@
+@import "../shared/style";
+
+.gravatar-enhanced-comments {
+	margin-bottom: calc(0.5 * var(--global--spacing-unit, 10px));
+	padding: var(--global--spacing-unit, 10px);
+	background-color: var(--wp--preset--color--white,white);
+	display: flex;
+	align-items: center;
+	gap: calc(0.5 * var(--wp--style--block-gap, 10px));
+
+	&.gravatar-enhanced-comments--hidden {
+		display: none;
+	}
+
+	img {
+		width: 64px;
+		height: 64px;
+		border-radius: 50%;
+
+		&.avatar {
+			position: inherit !important;
+		}
+	}
+
+	button {
+		background-color: transparent !important;
+		border: none;
+		padding: var(--global--spacing-unit, 8px);
+		color: var(--wp--preset--color--black, black) !important;
+		cursor: pointer;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}
+
+.gravatar-enhanced-is-loading {
+	@include pulsate();
+}

--- a/src/comments/style.scss
+++ b/src/comments/style.scss
@@ -44,10 +44,6 @@ $gravatar-blue: #1d4fc4;
 	}
 }
 
-.gravatar-enhanced-is-loading {
-	@include pulsate();
-}
-
 @keyframes borderFlashAndGrow {
 	0%,
 	100% {

--- a/src/comments/style.scss
+++ b/src/comments/style.scss
@@ -1,40 +1,63 @@
 @import "../shared/style";
 
+$animation-time: 0.2s;
+$gravatar-blue: #1d4fc4;
+
+.gravatar-enhanced-profile {
+	display: none;
+	background-color: transparent;
+	top: 0;
+	left: 0;
+	transition: left $animation-time ease-in-out;
+	position: absolute;
+	box-sizing: border-box;
+}
+
 .gravatar-enhanced-comments {
-	margin-bottom: calc(0.5 * var(--global--spacing-unit, 10px));
-	padding: var(--global--spacing-unit, 10px);
-	background-color: var(--wp--preset--color--white,white);
-	display: flex;
-	align-items: center;
-	gap: calc(0.5 * var(--wp--style--block-gap, 10px));
+	position: relative;
 
-	&.gravatar-enhanced-comments--hidden {
-		display: none;
-	}
+	.gravatar-enhanced-profile {
+		display: block;
 
-	img {
-		width: 64px;
-		height: 64px;
-		border-radius: 50%;
+		img {
+			width: 100%;
+			height: 100%;
+			border-radius: 50%;
+			cursor: pointer;
+			border: 2px solid transparent;
+			animation: borderFlashAndGrow 1s ease-in-out 2;
+			box-sizing: border-box;
 
-		&.avatar {
-			position: inherit !important;
+			&:hover {
+				border-color: $gravatar-blue;
+			}
+
+			&.avatar {
+				position: inherit !important;
+			}
 		}
 	}
 
-	button {
-		background-color: transparent !important;
-		border: none;
-		padding: var(--global--spacing-unit, 8px);
-		color: var(--wp--preset--color--black, black) !important;
-		cursor: pointer;
-
-		&:hover {
-			text-decoration: underline;
-		}
+	#email {
+		transition: padding-left $animation-time ease-in-out;
+		box-sizing: border-box;
 	}
 }
 
 .gravatar-enhanced-is-loading {
 	@include pulsate();
+}
+
+@keyframes borderFlashAndGrow {
+	0%,
+	100% {
+		border-color: transparent;
+		transform: scale(1);
+	}
+	25%,
+	50%,
+	75% {
+		border-color: $gravatar-blue;
+		transform: scale(1.1);
+	}
 }

--- a/src/discussion/index.ts
+++ b/src/discussion/index.ts
@@ -15,7 +15,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			forceDefault: entries.gravatar_force_default_avatar === '1' ? true : false,
 			proxy: entries.gravatar_proxy === '1' ? true : false,
 			proxyHash: entries?.gravatar_proxy_hash || '',
-		}
+		};
 
 		trackEvent( 'gravatar_enhanced_save_options', gravEntries );
 	} );

--- a/src/quick-editor/check-user-profile.ts
+++ b/src/quick-editor/check-user-profile.ts
@@ -1,6 +1,6 @@
 import { Hovercards, ProfileData } from '@gravatar-com/hovercards';
 import { Scope } from '@gravatar-com/quick-editor';
-import showQuickEditor from './show-quick-editor';
+import showQuickEditor from '../shared/show-quick-editor';
 import { convertJsonToUser } from '../hovercards/utils';
 
 interface ActionScope {
@@ -35,13 +35,14 @@ function createHovercard(
 		additionalClass: canEdit ? 'gravatar-hovercard--editable' : '',
 	};
 
-	const hovercard = Hovercards.createHovercard( user, options );
 	const container = document.querySelector( '.gravatar-hovercard-container' );
 	const loadingHovercard = document.querySelector( '.gravatar-profile__loading' );
 
 	if ( ! container || ! loadingHovercard ) {
 		return;
 	}
+
+	const hovercard = Hovercards.createHovercard( user, options );
 
 	Object.keys( actionSelectors ).forEach( ( selector ) => {
 		const actions = hovercard.querySelectorAll( selector );
@@ -141,6 +142,7 @@ async function fetchUserProfile( hash, avatar, text, openEditor, canEdit ) {
 
 		showValidProfile( avatar, profile, canEdit ? text.updateButton : text.viewButton, openEditor );
 	} catch ( error ) {
+		// eslint-disable-next-line no-console
 		console.error( error );
 
 		showError( text );
@@ -153,7 +155,10 @@ export default function checkUserProfile( { locale, email, hash, avatar, text, c
 		return;
 	}
 
-	const openEditor = ( scope ) => showQuickEditor( email, locale, scope, () => fetchProfile() );
+	const openEditor = ( scope ) =>
+		showQuickEditor( email, locale, scope, '.gravatar-hovercard__avatar, #wp-admin-bar-my-account .avatar', () =>
+			fetchProfile()
+		);
 	const fetchProfile = () => fetchUserProfile( hash, avatar, text, openEditor, canEdit );
 
 	setupSync();

--- a/src/shared/show-quick-editor.ts
+++ b/src/shared/show-quick-editor.ts
@@ -1,15 +1,12 @@
 import { GravatarQuickEditorCore, Scope } from '@gravatar-com/quick-editor';
-import trackEvent from '../shared/analytics';
+import trackEvent from './analytics';
 
 const UPDATE_DELAY = 2000;
 const LOADING_CLASS = 'avatar-loading';
-
 let quickEditor = null;
 
-function updateAvatars() {
-	const images: NodeListOf< HTMLImageElement > = document.querySelectorAll(
-		'.gravatar-hovercard__avatar, #wp-admin-bar-my-account .avatar'
-	);
+function updateAvatars( avatarSelector ) {
+	const images: NodeListOf< HTMLImageElement > = document.querySelectorAll( avatarSelector );
 
 	// Make all the avatars start pulsating
 	images.forEach( ( img ) => {
@@ -28,7 +25,13 @@ function updateAvatars() {
 	}, UPDATE_DELAY );
 }
 
-export default function showQuickEditor( email: string, locale: string, scope: Scope, updateProfile: () => void ) {
+export default function showQuickEditor(
+	email: string,
+	locale: string,
+	scope: Scope,
+	avatarSelector,
+	updateProfile: () => void
+) {
 	if ( ! quickEditor ) {
 		quickEditor = new GravatarQuickEditorCore( {
 			email,
@@ -37,7 +40,7 @@ export default function showQuickEditor( email: string, locale: string, scope: S
 			onProfileUpdated: ( type ) => {
 				if ( type === 'avatar_updated' ) {
 					trackEvent( 'gravatar_enhanced_qe_avatar_updated' );
-					updateAvatars();
+					updateAvatars( avatarSelector );
 				} else if ( type === 'profile_updated' ) {
 					trackEvent( 'gravatar_enhanced_qe_profile_updated' );
 					updateProfile();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,11 @@ interface GravatarAPIAccount {
 }
 
 declare global {
+	interface GravatarEnhancedComments {
+		locale: string;
+		email?: string;
+	}
+
 	interface GravatarAPIProfile {
 		hash: string;
 		display_name: string;
@@ -52,6 +57,8 @@ declare global {
 	var gravatar: {
 		recordTrackEvent: ( name: string, options?: any ) => void;
 	};
+
+	var gravatarEnhancedComments : GravatarEnhancedComments;
 
 	type SelectFn = typeof select;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,7 +58,7 @@ declare global {
 		recordTrackEvent: ( name: string, options?: any ) => void;
 	};
 
-	var gravatarEnhancedComments : GravatarEnhancedComments;
+	var gravatarEnhancedComments: GravatarEnhancedComments;
 
 	type SelectFn = typeof select;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const config = {
 		discussion: './src/discussion',
 		'wc-my-account': './src/woocommerce/my-account.ts',
 		'wc-admin-customers': './src/woocommerce/admin-customers.ts',
+		comments: './src/comments',
 		'patterns-shared': './classes/patterns/shared.scss',
 		'patterns-edit': './classes/patterns/edit.scss',
 		'patterns-view': './classes/patterns/view.scss',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,10 +1453,10 @@
   dependencies:
     tslib "2"
 
-"@gravatar-com/hovercards@^0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.10.5.tgz#f22eb8d6460c8256e81b7437d8785b5c46a190eb"
-  integrity sha512-NGgCLhdQbM8amUy4PtRJng+NhgjOC8o/tn4up3Hqp1lG8PEhytOXmV7M9dyDPYagtN6o7/DYrEf/kanv375lCg==
+"@gravatar-com/hovercards@^0.10.6":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.10.6.tgz#a7362f74c3ac46215a22670c79dda9cd081cf014"
+  integrity sha512-few7jQLKjn6/oN7maZXyoK6x008FwcshyHnATrAFDJP85XYIzp9lgiQa7zioNhiJXWaEd9MNiyjl0MlQJXwPDA==
 
 "@gravatar-com/quick-editor@^0.6.0":
   version "0.6.0"
@@ -3334,35 +3334,35 @@
     "@wordpress/dom-ready" "^3.58.0"
     "@wordpress/i18n" "^4.58.0"
 
-"@wordpress/a11y@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-4.18.0.tgz#35ce144c2d57ef0c32456d198f8081b9a9ce5953"
-  integrity sha512-aF/E6VtGHRUuNX4rJ8dJMNHKrYKsKoYVXI8n1oYg+Tbsq4fye5UJ3kLEGWLYoA8Yvvgsi2bvJ44IpBB4OhNCFg==
+"@wordpress/a11y@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/a11y/-/a11y-4.19.0.tgz#1ccf495730306505ea139592ee43cec39968cc57"
+  integrity sha512-lYhyBOeKO28A4V/Z+KTcmVyuNGS7WYJx0GEYAephfmiP925jOhrwnqBGdzhpx/X3lCHbY3EcpbjX4ka/jwzrkQ==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/dom-ready" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
+    "@wordpress/dom-ready" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
 
-"@wordpress/api-fetch@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-7.18.0.tgz#da161a000df90f9674021cd84cb14bdccede1714"
-  integrity sha512-mhzSIDRon8OWa1PLqo1gW35mfIkmjSXHteFJAmGHx7j3b/2+pa3THia8o2xYFXx+A0KWm0A3VOCuNUPp9q7aPg==
+"@wordpress/api-fetch@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-7.19.0.tgz#f0a1128a0f550dbb49fedc4c03c9962d98a7cc92"
+  integrity sha512-E36eCSuOpnQZZEElNrt1/EREGXatHjBdG8dyJ0HshADMQb/Llunl7LMvOiZgwO+FT11NnupqE42F+VDD605ElA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/url" "^4.19.0"
 
-"@wordpress/autop@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-4.18.0.tgz#e20881997f997912f0192008ca95f90129b81ff9"
-  integrity sha512-u+Gb8k41Af1TBd2967LSMN634acHyC2PlGCE5VpzrPInApb6REOwhf2nLh1ZUO1CC1f03pIyhqohhmNI/DwWrQ==
+"@wordpress/autop@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-4.19.0.tgz#b18b8ede67d46f6c070660be344b3cc59b9af33c"
+  integrity sha512-EZRJP7P2aeXyiARw1nPxiV6nc9wTYaeYJNLrgBy6BQpR2ivLxXDBgCwSmmQRT8LcNHwwIMsEJv8CqwuAnSkgWQ==
   dependencies:
     "@babel/runtime" "7.25.7"
 
-"@wordpress/babel-preset-default@^8.18.0":
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/babel-preset-default/-/babel-preset-default-8.18.0.tgz#4c767c7a9db55d376724fd95bf3d6b6206580e91"
-  integrity sha512-vx/UVMMqFhVDoLqymH8jmUC/YGq4p5oo2pgp9aqlYWBz/TO4H9LxMxWNGtcpZCagFBR85BeZD/467fO6UOO7Lw==
+"@wordpress/babel-preset-default@^8.19.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/babel-preset-default/-/babel-preset-default-8.19.0.tgz#6c0a93ed483668ccdd9762db691001bf1af8f24d"
+  integrity sha512-SGrQjsqa4BulfOCBw0zDYXnvnMzXUWeWLcdpLHPIGCHArSOrDddlyms5UFoJxVYVeN4aiEHVOoJRhxnamo3HUQ==
   dependencies:
     "@babel/core" "7.25.7"
     "@babel/plugin-transform-react-jsx" "7.25.7"
@@ -3370,65 +3370,65 @@
     "@babel/preset-env" "7.25.7"
     "@babel/preset-typescript" "7.25.7"
     "@babel/runtime" "7.25.7"
-    "@wordpress/browserslist-config" "^6.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/browserslist-config" "^6.19.0"
+    "@wordpress/warning" "^3.19.0"
     browserslist "^4.21.10"
     core-js "^3.31.0"
     react "^18.3.0"
 
-"@wordpress/base-styles@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-5.18.0.tgz#43baaa3e192f4a0117ac0fad7b64416a5a072704"
-  integrity sha512-3YUNMVRdV2XmhkSuhicxm51/QG+E5NH3uS15YV3wWf0PKiRQP1L72k037/tkNex9snDpIIBAGFAKfMIj5sP9Jw==
+"@wordpress/base-styles@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-5.19.0.tgz#86543771c1ea8a0e393104c990b7ae456faafb02"
+  integrity sha512-rDRt2G2H1uRLZGRF/aXe2WZGNJJ2yzBup1VaiYBNRKS7io2YRu54vEYMgh/ll1el5eMN+jO9t4A54Ew/DO470Q==
 
-"@wordpress/blob@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-4.18.0.tgz#f7e00c35d1e0680a869853a7da00218e131c3599"
-  integrity sha512-L9mcc/4aDgRuTSQmEfbwkVKWzTyvyHAw2FT6fqTiTzSOjQRtgndPMMEPhda29scEE79Hbx5+mZdoW41J32bnOQ==
+"@wordpress/blob@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-4.19.0.tgz#8940dee91ea2bde5ed907373227a1e791de87585"
+  integrity sha512-MZrLdLJaD5AXyTQ3lYT6xsgX5neyJe9wyo9L6/DWdKYotBA+VJdCuLulGzI7MGaJ9R5msiTvXdozHWqZMLnPvg==
   dependencies:
     "@babel/runtime" "7.25.7"
 
-"@wordpress/block-editor@^14.13.0":
-  version "14.13.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-editor/-/block-editor-14.13.0.tgz#ddf5f0ed58da4a6bae92f104ac7b2116d202c3a3"
-  integrity sha512-KRUWTHGM5jTzFrelG8oqHle5TiU5m4zB22d70mKMc2i4GqJKJ4Hd0nRJ/Z7vJmSCvR5UKV7f85kV4jhg1YNWlw==
+"@wordpress/block-editor@^14.14.0":
+  version "14.14.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-editor/-/block-editor-14.14.0.tgz#a5692fd57835341d6392afeba75c83732b9eebb3"
+  integrity sha512-bgPvD8w8+ezpXyEZtHKsjgcXsj5719mkj7bY4MKM2JYoKOjj2DxmK8pptm5JA6NwKGOOkdMh14qyHhvIIrkDkw==
   dependencies:
     "@babel/runtime" "7.25.7"
     "@emotion/react" "^11.7.1"
     "@emotion/styled" "^11.6.0"
     "@react-spring/web" "^9.4.5"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/block-serialization-default-parser" "^5.18.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/commands" "^1.18.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/date" "^5.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/dom" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/escape-html" "^3.18.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/keyboard-shortcuts" "^5.18.0"
-    "@wordpress/keycodes" "^4.18.0"
-    "@wordpress/notices" "^5.18.0"
-    "@wordpress/preferences" "^4.18.0"
-    "@wordpress/priority-queue" "^3.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/rich-text" "^7.18.0"
-    "@wordpress/style-engine" "^2.18.0"
-    "@wordpress/token-list" "^3.18.0"
-    "@wordpress/upload-media" "^0.3.0"
-    "@wordpress/url" "^4.18.0"
-    "@wordpress/warning" "^3.18.0"
-    "@wordpress/wordcount" "^4.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/block-serialization-default-parser" "^5.19.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/commands" "^1.19.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/date" "^5.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/dom" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/escape-html" "^3.19.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/keyboard-shortcuts" "^5.19.0"
+    "@wordpress/keycodes" "^4.19.0"
+    "@wordpress/notices" "^5.19.0"
+    "@wordpress/preferences" "^4.19.0"
+    "@wordpress/priority-queue" "^3.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/rich-text" "^7.19.0"
+    "@wordpress/style-engine" "^2.19.0"
+    "@wordpress/token-list" "^3.19.0"
+    "@wordpress/upload-media" "^0.4.0"
+    "@wordpress/url" "^4.19.0"
+    "@wordpress/warning" "^3.19.0"
+    "@wordpress/wordcount" "^4.19.0"
     change-case "^4.1.2"
     clsx "^2.1.1"
     colord "^2.7.0"
@@ -3444,34 +3444,34 @@
     react-easy-crop "^5.0.6"
     remove-accents "^0.5.0"
 
-"@wordpress/block-serialization-default-parser@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.18.0.tgz#8c18627e87238366bcf83cd386f8714c114af39b"
-  integrity sha512-ZviHll60ii6JDEhDV6EAuPd/utK2RihS2r3YCLFaQBaDrZ2xRMsL8Gaz8otCea/OiNxGzHW9A/O+rL6lwogLDw==
+"@wordpress/block-serialization-default-parser@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.19.0.tgz#cf3dba243a4008453af7a4663b68e4dc9ef2da37"
+  integrity sha512-bS6eIbmk2U3zor6uieX5KnHpVszGtpdW8WyGR0luk7TCBQsTh8u2WCKnYO57wJA7ZRslrrVOZYURgEfgB3lv8A==
   dependencies:
     "@babel/runtime" "7.25.7"
 
-"@wordpress/blocks@^14.7.0":
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-14.7.0.tgz#d345bfeaff1d1d5b75b925ea5120e08ea2452212"
-  integrity sha512-MQm52Mbr6mjOk949qKbA7kPwwpn80usFSYYy7THKZKXwk1DvxzrUUMWrO8OsgSp2TE9lnpGVVL3/O8PrzjWduA==
+"@wordpress/blocks@^14.8.0":
+  version "14.8.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-14.8.0.tgz#17a6c6be7c470d0bfa79b07c089082f3409b292d"
+  integrity sha512-iV9eGJU3Wdplj5xd4mfDeQcb3sqdsEo1bVb37uzOQpirbMBSJeVOsRkUohkEH1r651Asl/5OSG1gIyLflGIn4g==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/autop" "^4.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/block-serialization-default-parser" "^5.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/dom" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/rich-text" "^7.18.0"
-    "@wordpress/shortcode" "^4.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/autop" "^4.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/block-serialization-default-parser" "^5.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/dom" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/rich-text" "^7.19.0"
+    "@wordpress/shortcode" "^4.19.0"
+    "@wordpress/warning" "^3.19.0"
     change-case "^4.1.2"
     colord "^2.7.0"
     fast-deep-equal "^3.1.3"
@@ -3484,24 +3484,24 @@
     simple-html-tokenizer "^0.5.7"
     uuid "^9.0.1"
 
-"@wordpress/browserslist-config@^6.18.0":
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-6.18.0.tgz#15b485f7dd1536d8d3b7b2a1fad8b68af4b9f04f"
-  integrity sha512-GhB3p+qrR2xFITPEMi9/w2KoLhz0uzA+sMwtREr4G5UZ37dmgN3XJN55NYe2ZduT6uZnaCVYskOmXGvmx/EEyw==
+"@wordpress/browserslist-config@^6.19.0":
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/browserslist-config/-/browserslist-config-6.19.0.tgz#5f686cc9ac934058f9ae60c1f6ad16ca9031f8c0"
+  integrity sha512-4UR+T9iAx/qdehuZYZosL30PpPvzRVPncePs6aN0+zh7WbJsW4DZDi4ZXDTln6zJMIAQeHWvN84PTXgfsxyz4w==
 
-"@wordpress/commands@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/commands/-/commands-1.18.0.tgz#d6310e1498d8902fd75cb65c73a01b4e43615dfe"
-  integrity sha512-6MI5ff0SPn2NdO+qycNA09aTiMJ8BvwVmnC9c9jkOXyYEvYNLEPR6ez8wndMLXrJElGIFZRS5QjQDWQt8OmpgQ==
+"@wordpress/commands@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/commands/-/commands-1.19.0.tgz#4480f087f4d7a9e2b48f9f08de373823ed744703"
+  integrity sha512-rdSjI9ohKsb3edh6ir0/WFqCW6HqTowoDBuLaTKESjOjmLMIhiCQSJudq8v3iBz8yMDAmPQQY+79/kA66ABpEA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/keyboard-shortcuts" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/keyboard-shortcuts" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
     clsx "^2.1.1"
     cmdk "^1.0.0"
 
@@ -3558,10 +3558,10 @@
     use-lilius "^2.0.5"
     uuid "^9.0.1"
 
-"@wordpress/components@^29.4.0":
-  version "29.4.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-29.4.0.tgz#bf335eec8131cab83a126c249cad588edff6868d"
-  integrity sha512-jS0PnB/YpJuhFTGsFbRQYGD6w3zqqAkW+P1zv19crHNufrvNCv32jqNYv/2VIpEIZXKjo5Tkx0WvK8e1fm/7QA==
+"@wordpress/components@^29.5.0":
+  version "29.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/components/-/components-29.5.0.tgz#5983e5bb67b84dbb3ac42a106cf076a9670c91ab"
+  integrity sha512-Jp9wCwmsW/aAZk/J1mkMJGPKexpRVEsEsRw9z/dDwaFuxbz7TLzw481GUX7kDKgG83ZWTY7WjENRL45iasZzdQ==
   dependencies:
     "@ariakit/react" "^0.4.15"
     "@babel/runtime" "7.25.7"
@@ -3575,23 +3575,23 @@
     "@types/gradient-parser" "0.1.3"
     "@types/highlight-words-core" "1.2.1"
     "@use-gesture/react" "^10.3.1"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/date" "^5.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/dom" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/escape-html" "^3.18.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/keycodes" "^4.18.0"
-    "@wordpress/primitives" "^4.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/rich-text" "^7.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/date" "^5.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/dom" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/escape-html" "^3.19.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/keycodes" "^4.19.0"
+    "@wordpress/primitives" "^4.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/rich-text" "^7.19.0"
+    "@wordpress/warning" "^3.19.0"
     change-case "^4.1.2"
     clsx "^2.1.1"
     colord "^2.7.0"
@@ -3628,66 +3628,66 @@
     mousetrap "^1.6.5"
     use-memo-one "^1.1.1"
 
-"@wordpress/compose@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-7.18.0.tgz#e91a729e83a795ecd31c86fab6c0464f77b0e693"
-  integrity sha512-RtuSZyQu4dvbS6Ke7bDDN8O8qYwhJAvVn1hmreunQNQGSCH7vFYkzH4S5yphWOuPpUYNpMSbJnHJUPXuoojKkA==
+"@wordpress/compose@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-7.19.0.tgz#9ccf1945a6bdce057fe5abd3d3a46ccf05c36101"
+  integrity sha512-9BDf9Tlo+VXtaFIMGwnJ4Tiv8A/qVcvC33JWcK/YjlIgtdEhLcp5GqbTXC9qaAAv0giHQCNPjWv1YtHBB5kRBQ==
   dependencies:
     "@babel/runtime" "7.25.7"
     "@types/mousetrap" "^1.6.8"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/dom" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/keycodes" "^4.18.0"
-    "@wordpress/priority-queue" "^3.18.0"
-    "@wordpress/undo-manager" "^1.18.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/dom" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/keycodes" "^4.19.0"
+    "@wordpress/priority-queue" "^3.19.0"
+    "@wordpress/undo-manager" "^1.19.0"
     change-case "^4.1.2"
     clipboard "^2.0.11"
     mousetrap "^1.6.5"
     use-memo-one "^1.1.1"
 
-"@wordpress/core-data@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-7.18.0.tgz#7765f31fa81fdfaabc6f9588bb7536214237e277"
-  integrity sha512-czih27KNEnJQDpY7m0VLwlpAEZZHa6IO7rXIwmCF9JnjYERM6gYPdBTApQUhuyc11QN9E6jzSgfE/5tzRQhd+g==
+"@wordpress/core-data@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-7.19.0.tgz#32b2fc0b63790c293c2d0b00cd0fb6d7d921f578"
+  integrity sha512-m15aePuUEthZarEqcki9QMpOrVj2S4TBMZ6NQz3S6Oi1jbcrGhLjVyFTyzdlxz2EeaA9kITgaa/lQIoS6lWiXg==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/block-editor" "^14.13.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/rich-text" "^7.18.0"
-    "@wordpress/sync" "^1.18.0"
-    "@wordpress/undo-manager" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/block-editor" "^14.14.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/rich-text" "^7.19.0"
+    "@wordpress/sync" "^1.19.0"
+    "@wordpress/undo-manager" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
+    "@wordpress/warning" "^3.19.0"
     change-case "^4.1.2"
     equivalent-key-map "^0.2.2"
     fast-deep-equal "^3.1.3"
     memize "^2.1.0"
     uuid "^9.0.1"
 
-"@wordpress/data@^10.18.0":
-  version "10.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-10.18.0.tgz#bc291a32bc330625fd6800f24018b34ebf82914d"
-  integrity sha512-GKuwP+0gJ5vUrgZ8xPIGUHTQcwzr2GzUuqbOX50exrd/V1veUa0wu8tILrflB6RYECdMdtoLxSfX+WVgtpEzlg==
+"@wordpress/data@^10.19.0":
+  version "10.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-10.19.0.tgz#84551a64e068f1fa8436f2453adb1d8bbb354b22"
+  integrity sha512-lBVchfFGcrGCQggMcgYc9ZiYSM5/53c+Vj9icv6xrVGVDN4tEIoGFF3YC95OkTWw98u+KGq89EkWsR8pyyvt4w==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
-    "@wordpress/priority-queue" "^3.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/redux-routine" "^5.18.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
+    "@wordpress/priority-queue" "^3.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/redux-routine" "^5.19.0"
     deepmerge "^4.3.0"
     equivalent-key-map "^0.2.2"
     is-plain-object "^5.0.0"
@@ -3717,22 +3717,22 @@
     rememo "^4.0.2"
     use-memo-one "^1.1.1"
 
-"@wordpress/dataviews@^4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/dataviews/-/dataviews-4.14.0.tgz#563cd8c331e90bbee50629d9d2d4e817637aa9ad"
-  integrity sha512-0PYrsnirj4FZxcrzaUlTxLSRFO9JVyCNfzhRYQGUrIPuAF2hBtYNUBNYZLcsCgcLG1W9NNcHJKX/SaBV47dF1g==
+"@wordpress/dataviews@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dataviews/-/dataviews-4.15.0.tgz#2291832bbed7075990ff847eddbef8f8d0ad5866"
+  integrity sha512-lx2srFMH2HTnx9eonaNTTNR6j++fw916fG0ugT93iLV0xka+Hbl0aq7puy5+LrMcDfgcU+N/+UkqijilwxBhAQ==
   dependencies:
     "@ariakit/react" "^0.4.15"
     "@babel/runtime" "7.25.7"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/primitives" "^4.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/primitives" "^4.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/warning" "^3.19.0"
     clsx "^2.1.1"
     remove-accents "^0.5.0"
 
@@ -3746,20 +3746,20 @@
     moment "^2.29.4"
     moment-timezone "^0.5.40"
 
-"@wordpress/date@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-5.18.0.tgz#e695a4d95d5af1889f6aa0c72e86ac8a4b7820c8"
-  integrity sha512-x5k5pobYHq83BydLnHBOaMwuhqRafRYAgAs0aq5F08C5s33qg7JEKCJbiYZbAH/d9MeDrfAQwlFE9oj5Fx8yew==
+"@wordpress/date@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-5.19.0.tgz#979b2fbab53327c6a85d1c07722e79a18fa5a755"
+  integrity sha512-EZ31S8za/SRpUhgLSbKePaWIFuuLy5YzU0k9pdbxw3bc6qjC8Yfl72Envw0oMqgBbylYNGJa+hfeNEBWzDBKMA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/deprecated" "^4.18.0"
+    "@wordpress/deprecated" "^4.19.0"
     moment "^2.29.4"
     moment-timezone "^0.5.40"
 
-"@wordpress/dependency-extraction-webpack-plugin@^6.18.0":
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.18.0.tgz#e86553b83567a4f6dae1b5a85d5f9f94137ccbb0"
-  integrity sha512-OKW8CwbZEU5AoTx+hW00iaWBUywa2xuX5nrJuqYOAMi4OVgjiNqcjUmamAHNPWtw4jvxBbodd78B18BHRtEonQ==
+"@wordpress/dependency-extraction-webpack-plugin@^6.19.0":
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.19.0.tgz#3b7702f1fb298bddc9c01e5328492d849e36ed62"
+  integrity sha512-j23efbWFAVww9SvQ5GXGVXrqWEB+9OdlS+4qT5ojjSkXkUgJMm4bOzaFzIlgRmgGZNc3kpJ/0iIJF0lkK3U6uw==
   dependencies:
     json2php "^0.0.7"
 
@@ -3771,13 +3771,13 @@
     "@babel/runtime" "^7.16.0"
     "@wordpress/hooks" "^3.58.0"
 
-"@wordpress/deprecated@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-4.18.0.tgz#5bf1ecfcdf4c810d85721bc0917f57229e98509e"
-  integrity sha512-GtTmirQsz4NmSLOyLGL6MmWBM41M0lAet2nWhkf8gmyoO2n7bc7UpyqxiyijW7R6N2imvvJyD5ZMqLRBBVk/IQ==
+"@wordpress/deprecated@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-4.19.0.tgz#73ea51b1c3ceaf3e95ebd6f0d2486dc01ec385a1"
+  integrity sha512-PlOodANvm8IfznNwPv+gLV83wLSV1MDnkQ+An3NIod0uEgapqRztqpuMCLZIsk/uHyrPas3eg7aNyjOk3tHT7Q==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/hooks" "^4.18.0"
+    "@wordpress/hooks" "^4.19.0"
 
 "@wordpress/dom-ready@^3.58.0":
   version "3.58.0"
@@ -3786,10 +3786,10 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/dom-ready@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-4.18.0.tgz#90bda701eddaa4309243229aabcbbf64ab42d156"
-  integrity sha512-LRzvHy1OTiqm7Uww70ByjqLzovoXRy6PPKAlHUrFxuK/0v9QNJ5ha0Q57PYwrZZVm2Hjkt2SQ8OdIZESaoI2/g==
+"@wordpress/dom-ready@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-4.19.0.tgz#d428a16af5853eeb33cf86900dfdb7f1378e5396"
+  integrity sha512-R7Go813c/2mY2AmgtT3+2uffn5obxPKGyhCSVYvURmWKERFAoLHpvO4Fbb8ofPZP9GcwZBV+5We2SnYcRwyqlw==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -3801,18 +3801,18 @@
     "@babel/runtime" "^7.16.0"
     "@wordpress/deprecated" "^3.58.0"
 
-"@wordpress/dom@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-4.18.0.tgz#c1b95076750c23a4d4ad804ef5135bd86f358ac3"
-  integrity sha512-EHGyFnr/XciaeivOkGlny+LZMce3keVDDV3ioanmZ8ei6XBvMhu53ckBRjGstMVC7WtEpcCp65pjIvdCCiFDtQ==
+"@wordpress/dom@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-4.19.0.tgz#d46e4f63468863a0179ba16b161b938fb9c99b24"
+  integrity sha512-/9+ITib+cJ4nffSFzhSE4XDesQf/y9hXsQrghXgG7NhMKNBmpNNOP9Jc1oifxVl5PCopKm/swck753F8DFfn+g==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/deprecated" "^4.18.0"
+    "@wordpress/deprecated" "^4.19.0"
 
-"@wordpress/e2e-test-utils-playwright@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.18.0.tgz#4e7ac055ad4ad10a3d57794f65933c82a5fd06ac"
-  integrity sha512-SGYU724cFM/EmDoTu9pVI+H2PLln9/NIKaxOLLhMhCBqb15nf6VzBU1ux1qHtG6YDA62S+kxO3gyI40amvX6Sg==
+"@wordpress/e2e-test-utils-playwright@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.19.0.tgz#da7208ad936f42756c5abc14e6be4c71c7662f89"
+  integrity sha512-oVAymk10VFF6vlhOveDvj6M9wqDbz434pyZ7V7OR2lF1O9A6npi1BJ3RNmKx8ar4J79tNaehr3I9G0B45WCH7Q==
   dependencies:
     change-case "^4.1.2"
     form-data "^4.0.0"
@@ -3821,47 +3821,47 @@
     mime "^3.0.0"
     web-vitals "^4.2.1"
 
-"@wordpress/editor@^14.18.0":
-  version "14.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-14.18.0.tgz#8a7c3b4d9c62906ca972de7d94b765505de5fd2d"
-  integrity sha512-SN/B8onomEBg4sHYihgSJesIZ3wi8QlecEDGe6NeAcf/yugDkUW2k/lTLhBLGgA7tEfLEi5vsKDhlVjpHjb4zA==
+"@wordpress/editor@^14.19.0":
+  version "14.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/editor/-/editor-14.19.0.tgz#b978ad0da07bc84caea797d05d2ce97ce385015c"
+  integrity sha512-vUMm/hR1vEwAcVv5QM6I+q+vrea9mYB2YmHWW26b1LJ7n9YCsnPSNucgxIeEwqh1V/1jhh2C+Vu/zOEs5TCOqA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/block-editor" "^14.13.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/commands" "^1.18.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/core-data" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/dataviews" "^4.14.0"
-    "@wordpress/date" "^5.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/dom" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/fields" "^0.10.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/interface" "^9.3.0"
-    "@wordpress/keyboard-shortcuts" "^5.18.0"
-    "@wordpress/keycodes" "^4.18.0"
-    "@wordpress/media-utils" "^5.18.0"
-    "@wordpress/notices" "^5.18.0"
-    "@wordpress/patterns" "^2.18.0"
-    "@wordpress/plugins" "^7.18.0"
-    "@wordpress/preferences" "^4.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/reusable-blocks" "^5.18.0"
-    "@wordpress/rich-text" "^7.18.0"
-    "@wordpress/server-side-render" "^5.18.0"
-    "@wordpress/url" "^4.18.0"
-    "@wordpress/warning" "^3.18.0"
-    "@wordpress/wordcount" "^4.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/block-editor" "^14.14.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/commands" "^1.19.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/core-data" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/dataviews" "^4.15.0"
+    "@wordpress/date" "^5.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/dom" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/fields" "^0.11.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/interface" "^9.4.0"
+    "@wordpress/keyboard-shortcuts" "^5.19.0"
+    "@wordpress/keycodes" "^4.19.0"
+    "@wordpress/media-utils" "^5.19.0"
+    "@wordpress/notices" "^5.19.0"
+    "@wordpress/patterns" "^2.19.0"
+    "@wordpress/plugins" "^7.19.0"
+    "@wordpress/preferences" "^4.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/reusable-blocks" "^5.19.0"
+    "@wordpress/rich-text" "^7.19.0"
+    "@wordpress/server-side-render" "^5.19.0"
+    "@wordpress/url" "^4.19.0"
+    "@wordpress/warning" "^3.19.0"
+    "@wordpress/wordcount" "^4.19.0"
     change-case "^4.1.2"
     client-zip "^2.4.5"
     clsx "^2.1.1"
@@ -3888,15 +3888,15 @@
     react "^18.3.0"
     react-dom "^18.3.0"
 
-"@wordpress/element@^6.18.0":
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-6.18.0.tgz#caf71c220440f03ad1951e4bdcae6d59afb3679e"
-  integrity sha512-38wA2ta4GGOxuKofmyNP+EWA03bqBwUufQNQNd8GgcaKo4N/j+0wQMouLC/2g6n9MU5B0DH4tIv9uP9qR1miYg==
+"@wordpress/element@^6.19.0":
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-6.19.0.tgz#18de6e2a2ac7992b3b6465f41ca9e962058cab68"
+  integrity sha512-11kWRNiHbDkm5uXxEQiVVcEmdUHzBUjzsgp7Ui1iT8yDp0Taf8F30GzqGlWiu0B1K9VxUYLgVCqXamNqo64Ahg==
   dependencies:
     "@babel/runtime" "7.25.7"
     "@types/react" "^18.2.79"
     "@types/react-dom" "^18.2.25"
-    "@wordpress/escape-html" "^3.18.0"
+    "@wordpress/escape-html" "^3.19.0"
     change-case "^4.1.2"
     is-plain-object "^5.0.0"
     react "^18.3.0"
@@ -3909,23 +3909,23 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/escape-html@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-3.18.0.tgz#615cdf256ad716c52c52d516617db9eb000956f3"
-  integrity sha512-5hcsoIin5IYAEejuRJqnFQB5q5C0q8VII/H7wWOWoe8IXiRQCiju/DWRC25AL2xWdUdaqiG84JuiPq+7Npb8gw==
+"@wordpress/escape-html@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-3.19.0.tgz#b203f877a1557b05799ba0b09216ab0c19c31934"
+  integrity sha512-vG2h1e/+MmLupGzseeoveB+48wz+ZhB9FhJ+yl0B19H/n4PfcSBl3XD0EPw9iAM6y6KMST/2qqkdFGNwohdnmA==
   dependencies:
     "@babel/runtime" "7.25.7"
 
-"@wordpress/eslint-plugin@^22.4.0":
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/eslint-plugin/-/eslint-plugin-22.4.0.tgz#fcde7ee74947c6e1c33fa49cee9143993eb68d16"
-  integrity sha512-h+QrGdBRI3dnsNjlvCRt7Y9m4btzGcve0PymqmOeckmdEUGjt+6CCz2uS2Mbn8DRx5+1PCBD8SxCv6/J7ek2ow==
+"@wordpress/eslint-plugin@^22.5.0":
+  version "22.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/eslint-plugin/-/eslint-plugin-22.5.0.tgz#024b45c21d9c35b469328e864a8af9ded88f241c"
+  integrity sha512-hmmPqOnyrSup3zNAk/sZGzURK/2+8EXRIMsX3/34kskhDPeWMYSiNt9pApFZ5dDR0fwlDLSmsOiZpDTCsZic+w==
   dependencies:
     "@babel/eslint-parser" "7.25.7"
     "@typescript-eslint/eslint-plugin" "^6.4.1"
     "@typescript-eslint/parser" "^6.4.1"
-    "@wordpress/babel-preset-default" "^8.18.0"
-    "@wordpress/prettier-config" "^4.18.0"
+    "@wordpress/babel-preset-default" "^8.19.0"
+    "@wordpress/prettier-config" "^4.19.0"
     cosmiconfig "^7.0.0"
     eslint-config-prettier "^8.3.0"
     eslint-plugin-import "^2.25.2"
@@ -3939,35 +3939,35 @@
     globals "^13.12.0"
     requireindex "^1.2.0"
 
-"@wordpress/fields@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/fields/-/fields-0.10.0.tgz#64f39134c0529787a676958af456247afd721e8a"
-  integrity sha512-1JcX5EdYiw43Mx3qiTTPE295FsqHJ1d8hnaMFQhdLuVhMRlz1hOSXTn6wL6BwcCsc1/KOBLX7OAFbNohwGGbqg==
+"@wordpress/fields@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/fields/-/fields-0.11.0.tgz#4b38a6d73a42732226bc0f170ebdcba8ee4f2fda"
+  integrity sha512-q2uHvRywTM0I7aTceRAgHv0OzNZP7oCt05AC3qxlBNoALHSiyIXjzranHUPZWuj693WMEDPYsP7AawwC+YP0UQ==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/block-editor" "^14.13.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/core-data" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/dataviews" "^4.14.0"
-    "@wordpress/date" "^5.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/media-utils" "^5.18.0"
-    "@wordpress/notices" "^5.18.0"
-    "@wordpress/patterns" "^2.18.0"
-    "@wordpress/primitives" "^4.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/router" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
-    "@wordpress/warning" "^3.18.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/block-editor" "^14.14.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/core-data" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/dataviews" "^4.15.0"
+    "@wordpress/date" "^5.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/media-utils" "^5.19.0"
+    "@wordpress/notices" "^5.19.0"
+    "@wordpress/patterns" "^2.19.0"
+    "@wordpress/primitives" "^4.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/router" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
+    "@wordpress/warning" "^3.19.0"
     change-case "4.1.2"
     client-zip "^2.4.5"
     clsx "2.1.1"
@@ -3980,10 +3980,10 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/hooks@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-4.18.0.tgz#d4ed618c04e9604a3dc0e1c6c77acb4593f9beb1"
-  integrity sha512-hJulGAT2ELS+UBCTPnTe2A2ep+sOF4PO/x41UmeSgiaIJV1G4xNCJnlcyuCsV3xI2CTnf+YqjyS3qbqhLq3YOA==
+"@wordpress/hooks@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-4.19.0.tgz#ee2dcfe8b141fbde51c0ae9688dc336b45635a09"
+  integrity sha512-fIISVBC8XtZEtltYYm1yCgJiBw3TkDI5hXuIyTaJAlOWwcjj7geyjghd0lsIbr5CerTrh9/rPG121M+uvHK5NQ==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -3994,10 +3994,10 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/html-entities@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-4.18.0.tgz#6f19051eaf0eaeccd5ee500c19431ba15b6cd424"
-  integrity sha512-g0XTnspjAQNKpj3dVcFxYZaDcxbEfAx9rsosYksgnvaVoMBvCmzlaNIa6QAjmsjwryoNi8ugx2CkCxde1lVp2Q==
+"@wordpress/html-entities@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-4.19.0.tgz#96cedb473776356e7893320507651794ec1b069c"
+  integrity sha512-MMu5eVRBhwxBsYxi2iEEhcGSYb9ct9m7ttVdSSacQvKY8NNGhm99XIPhpXNnFFcd3Eb1E/JPxCEs4ROA16K8NA==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -4013,26 +4013,26 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
-"@wordpress/i18n@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-5.18.0.tgz#664ce83c4d478943b5803cddfcbc1ba1cb0b887e"
-  integrity sha512-XaA3qSyOnmx7FEQFwOXxqWLVjKw0TWR/S/sEmp6Rs88ttUDS0Y6z6xGwCwEK8acmUUWccaxk6aPirX8gV4Bdrw==
+"@wordpress/i18n@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-5.19.0.tgz#e05f1da2543896e3980abb36b443d10062d1db76"
+  integrity sha512-xDH8cA2rJb4yFB939nPS9605VxSEaVj07R89HxZrjdolDPxVpESBtpn2nV4Ll7pQtDIlaE9PPPtcnuu1JN6hAw==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/hooks" "^4.18.0"
+    "@wordpress/hooks" "^4.19.0"
     gettext-parser "^1.3.1"
     memize "^2.1.0"
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
-"@wordpress/icons@^10.18.0":
-  version "10.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-10.18.0.tgz#ba1e23cf5ae58502dd8f8f016fd0f57bdfe83b7d"
-  integrity sha512-stWW0msTspv6wCB3Pcu7PtVoFQBRr4R+oOvXlxVnpsUKuUz+mIAS08Sme9bTkHiVtHBZRK6YGpt4wYK6W0FXcw==
+"@wordpress/icons@^10.19.0":
+  version "10.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-10.19.0.tgz#0a86aadd097f65ca40500022c99ca290e7ec6fba"
+  integrity sha512-bYIzWgK3pLI/ShAzkhtzesy/f77WdC7CUdY6kbyic6Q706E3NOqHPeEyvecyOXJn9LKjwtes9jcnjOehNIyuxw==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/primitives" "^4.18.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/primitives" "^4.19.0"
 
 "@wordpress/icons@^9.49.0":
   version "9.49.0"
@@ -4043,23 +4043,23 @@
     "@wordpress/element" "^5.35.0"
     "@wordpress/primitives" "^3.56.0"
 
-"@wordpress/interface@^9.3.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/interface/-/interface-9.3.0.tgz#e9dceeaa2e96445c6cb14d8d235437899d7ec94d"
-  integrity sha512-mumbsuAzLyUvDnzMUJCYtO26C74yPtMQ1Se8MoPyQq5e+1bPjd/MtjBWXYqY+aNS31yme/n7N0X77ea7w6t7YQ==
+"@wordpress/interface@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/interface/-/interface-9.4.0.tgz#b0adf090154af029de6c517d72d4b5ba743b4d56"
+  integrity sha512-RJ8X/wDhR4l0fgBtVzl5may1+iS4Gj65BVdP8xJz0bnse+n0w+USLZKeURJLFRcO2hooxxTxlPzWBObeVI/Q7g==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/plugins" "^7.18.0"
-    "@wordpress/preferences" "^4.18.0"
-    "@wordpress/viewport" "^6.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/plugins" "^7.19.0"
+    "@wordpress/preferences" "^4.19.0"
+    "@wordpress/viewport" "^6.19.0"
     clsx "^2.1.1"
 
 "@wordpress/is-shallow-equal@^4.58.0":
@@ -4069,38 +4069,38 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/is-shallow-equal@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-5.18.0.tgz#c01eacb5235df77ee05b2191e78403312c448542"
-  integrity sha512-g8MGRyDTwpJXK/Pxp1aU/uprBV1pqYcB4sBlt5E5rck/8OlAwYzePgR7TShBT6kLs9UGi9a3k8StPilnX54GMQ==
+"@wordpress/is-shallow-equal@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-5.19.0.tgz#38258f9d9a50dde872d96df886badf2be86b59e0"
+  integrity sha512-IzXZXxdv6r6fAQXUKvWnvZSATY1gwkYa/IK/hC3db/O1Xd9vd2WAQVV6URoSNidW1HRtONAFs3V0bhaaQJG+KQ==
   dependencies:
     "@babel/runtime" "7.25.7"
 
-"@wordpress/jest-console@^8.18.0":
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/jest-console/-/jest-console-8.18.0.tgz#d59a4891bc91fd337d96b60d2b83ba5caf888280"
-  integrity sha512-PzqkJ86yjDSwufWs4hhmWFvGwIUX/t1ADwxiET8n5/fVzERx67SeHDR6YyBxovO5ruwiK6jpdCQ5F9QAPSGM1Q==
+"@wordpress/jest-console@^8.19.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/jest-console/-/jest-console-8.19.0.tgz#2b8adc299fc70b9a9f98d5c626f634c285cf4fc7"
+  integrity sha512-HwXWaRmrT5bA4rWUnIGJNgqQrF7eeQmHxBN/fy8gcag4Le1/v92EpUjsIAT+lMJVahoqmGbyzkXFdZ2TAvwLtw==
   dependencies:
     "@babel/runtime" "7.25.7"
     jest-matcher-utils "^29.6.2"
 
-"@wordpress/jest-preset-default@^12.18.0":
-  version "12.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/jest-preset-default/-/jest-preset-default-12.18.0.tgz#97321445646f8331dcf87eed4b508e12347610c9"
-  integrity sha512-58kidVChlzC6qtRvt56u40/E4NM1nMvilYBynZwev5rEe7r7AdxL/JRSaHDZaIqz1s0ai5Cej64dWC7gMScMxA==
+"@wordpress/jest-preset-default@^12.19.0":
+  version "12.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/jest-preset-default/-/jest-preset-default-12.19.0.tgz#0037563dbd62b8f3e4d08ae891350ca00b798832"
+  integrity sha512-WciJ2Qiblxd4Y0ysGgGZPTwGPRfvb+WyRF9zyJ5Oa0a5LpfrSUv8tjx9pOTz2hi30vhj34LFoqpWCcGXJZ56Aw==
   dependencies:
-    "@wordpress/jest-console" "^8.18.0"
+    "@wordpress/jest-console" "^8.19.0"
     babel-jest "29.7.0"
 
-"@wordpress/keyboard-shortcuts@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.18.0.tgz#4d0ca3438abdfce0f4097c129d75a416353f5892"
-  integrity sha512-FY+j85svtDR3fsfLbzKUClxTYaBVgCWLwYxlyNVF07uVZRSn6Y3josXrfhn1YzBH9lvzyxIb7pZprFVRFUwtKw==
+"@wordpress/keyboard-shortcuts@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.19.0.tgz#0e05e6edaa78e62bc52b4550b3268f71b4262b7a"
+  integrity sha512-PEtbFuqjop3XZDnr3U9sygH/6B2gL/nmKX1QlhO+BPmDyxIQf6Jt9nMAMR62foVhwxhtPamDRzH/nqnPgXi5XQ==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/keycodes" "^4.18.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/keycodes" "^4.19.0"
 
 "@wordpress/keycodes@^3.54.0", "@wordpress/keycodes@^3.58.0":
   version "3.58.0"
@@ -4110,105 +4110,105 @@
     "@babel/runtime" "^7.16.0"
     "@wordpress/i18n" "^4.58.0"
 
-"@wordpress/keycodes@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-4.18.0.tgz#39ea43576f806345be85dead28d3b230d76f2c27"
-  integrity sha512-96dkj/z0eDsA9kfM+vMsaY9MLUZGO9zJMlklkyaGltsVqrO/WhlNPEui7/JerJ+YUL0oncdUaGiwcj5pKs09cA==
+"@wordpress/keycodes@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-4.19.0.tgz#43d568d2905bdd96881c057d384e9a9031d4245f"
+  integrity sha512-V1Su6kndEV1Nrv+tps97QEK9N1vZEbNPWU5lwCc/nUxODtOk+A6J1SkUcDmbzbZ/FYtNWXBffG7ZXI9hzX8cxw==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/i18n" "^5.18.0"
+    "@wordpress/i18n" "^5.19.0"
 
-"@wordpress/media-utils@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/media-utils/-/media-utils-5.18.0.tgz#66ae75574f8da8762361ccf3b173a037097f99ae"
-  integrity sha512-qjsM/ujuqVOkknLSt67dX1w47WT+5Vfmz2urp7c/lidUKzBpRYcJhDpm1iQCuHJ8TCL6tVz0O29oNGFyItYBIg==
+"@wordpress/media-utils@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/media-utils/-/media-utils-5.19.0.tgz#a4a21e2ad3e95cbdbb6fd815f9ad0468e5ab36f7"
+  integrity sha512-SCBrcUttktrqC5facpd29d1bbOee1vWqt+Eg2Wggjvu14A9yWbJKYjfbeHCJYiEJoaFft+WuW4Vq5RSy/QcRjw==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
 
-"@wordpress/notices@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/notices/-/notices-5.18.0.tgz#9a64f7a9bc7e7c3f58cfc5772c063482eb7c7791"
-  integrity sha512-JBEbMtcdKn1hTzSLi6TPgO+09VHyOdlhyuVVV56rxg1S6bmq2DKvLuMYFiF4KpBaDHPPqQho9adHpozx1TAYkg==
+"@wordpress/notices@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/notices/-/notices-5.19.0.tgz#7a73b578aa41fca9ff38466f534be01f08acf4fa"
+  integrity sha512-MCJKAx4+xkITmCB0tT2YSNqs+tnCqZAQcwFhTXFHezb8t7pLVyFZCUmpHuaIttyr7BiYp46tH9dC6ZDkwQhXeA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/data" "^10.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/data" "^10.19.0"
 
-"@wordpress/npm-package-json-lint-config@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.18.0.tgz#9ce6bb0ce16236cca864199e075192343c9df023"
-  integrity sha512-6pjCa0BteHjfo1bdByKIZYR8Cr2wNwXi2DylgazFSkvpabdFa5X04bDXFZZGHGiZq/MkajiJ8iOTUgckpUjATQ==
+"@wordpress/npm-package-json-lint-config@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.19.0.tgz#e7c51972862896209042270b00a912bdd884366b"
+  integrity sha512-6JrZWHAQbji0k8rf7/fEnDP0Ie5qGBLaA5deMkVTC75HtEoiH+rR+ssVsdvv7+KyerM+5LDP6Aef5rVE7vsteA==
 
-"@wordpress/patterns@^2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/patterns/-/patterns-2.18.0.tgz#e028ba728339ce37b7dda6d057b91f5e261b4044"
-  integrity sha512-84+yM89KbKjFklqT5nJ6FNnXjadN+Ypn21SARbe+F9D5Pfd+JsxTfMVz6PjxzIrDr9O0594VSbxu9ISSlDy3jA==
+"@wordpress/patterns@^2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/patterns/-/patterns-2.19.0.tgz#43f0fb9acda47ae1eba6a60a7879c0be483efec6"
+  integrity sha512-smnQnYBee7+P0XNjAaf8p7/rLJPxrkvdE4SPE9ecVMp0VlIj+qXCMTnxaVVmaDWjxZjC/nGUjXdvTcfIQcj0OA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/block-editor" "^14.13.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/core-data" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/html-entities" "^4.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/notices" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/block-editor" "^14.14.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/core-data" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/html-entities" "^4.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/notices" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
 
-"@wordpress/plugins@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-7.18.0.tgz#a05fd2304e55ad2cb1135d343e19fbe8943674a1"
-  integrity sha512-WcgesvabfDD2vaNGpPRRRCN1coUgnpX+LVWMl+x5xISRxnTeeTbAPzl125B7xhv+N98JcQCZOen0+xO3/4yIRA==
+"@wordpress/plugins@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-7.19.0.tgz#f47c75bd8501699f9905fe8d8497c592c2398f28"
+  integrity sha512-MvzFT1bCRVp78FtiTEBw+4J2SEJH9gf8Byhtw/Rwl9NNWdTYZYRjka9QkObxJGk6R6XocPQCV4XnzFA/8P/u0w==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/hooks" "^4.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/is-shallow-equal" "^5.18.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/hooks" "^4.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
     memize "^2.0.1"
 
-"@wordpress/postcss-plugins-preset@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.18.0.tgz#3ca0cc06345c4d44810f0fa3b384ae4da4d2e6de"
-  integrity sha512-bdw4wNs/1B/o16tPwZoSCp0Q6yApd4lcAFFFuHKCBWhJjLfVxR1yLRYXcUcANJG72kN5TKrPGPmwxkz2B8lXFA==
+"@wordpress/postcss-plugins-preset@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.19.0.tgz#64cb33f2c2fc1509882b423c1511ca49eefb06e8"
+  integrity sha512-sHQ9rasbQztxG2ZgbZ34G7u94CS0RHcvbQFLqijazlSX6QhAFporJlgzHhyHO+yRFNBHQ+3vvDZCS3BMEjxiOg==
   dependencies:
-    "@wordpress/base-styles" "^5.18.0"
+    "@wordpress/base-styles" "^5.19.0"
     autoprefixer "^10.4.20"
 
-"@wordpress/preferences@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/preferences/-/preferences-4.18.0.tgz#33a8bd3672d093549cb6299c306b8fbaf294486b"
-  integrity sha512-hFpzDgZim4dH07IVtxAgGjN3mYDHWWPHrA6nqA0RxhU4MalRB6jvL+AWFKJtWk3P4bv14O854s7zJ+x5Dj6Ceg==
+"@wordpress/preferences@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/preferences/-/preferences-4.19.0.tgz#9872e2733ac093761da83b95efbc502c508f1dbd"
+  integrity sha512-G7rzTs/XHrJEHcgGNr7uYQTUR7kp2w/QkR7W7d38wa5MkoZR0oINqYsUiXcgD66sd0CkEd2iYrPgRHXLH20J2A==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/private-apis" "^1.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/private-apis" "^1.19.0"
     clsx "^2.1.1"
 
-"@wordpress/prettier-config@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/prettier-config/-/prettier-config-4.18.0.tgz#d8340c6b962a2ee235bb2bf848b7204b21324133"
-  integrity sha512-VsFFqSBpMw5u2kq1OTQeSMTUrznnAuZ0Z7+41MOsyJjb9DFX2Yq6k1FcmUhBJWDLEvkunMorSZ7kqhUxHWPR+g==
+"@wordpress/prettier-config@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/prettier-config/-/prettier-config-4.19.0.tgz#c9f65b36c59d55f037f0422bb3a74aa6e9ae58e6"
+  integrity sha512-mGgPuhIupWln2UX0uqLBfvvEzWFb1r2oRCC5Q3RXNtjDdOnkKIqtJOjCqL8IkCxa0sJmQZUymHKxBnStlQxR0w==
 
 "@wordpress/primitives@^3.56.0":
   version "3.56.0"
@@ -4219,13 +4219,13 @@
     "@wordpress/element" "^5.35.0"
     clsx "^2.1.1"
 
-"@wordpress/primitives@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-4.18.0.tgz#59684dc105b3011be0c436bc04bbb78eaa271e83"
-  integrity sha512-c/8wC1MgbiQc/8kQlxuNuzeDeEW65jHSK0/qZ/afvHL1T4AmYmyC791nabpyGM+Le1kwe1LCDbPo/x2Oig0nbA==
+"@wordpress/primitives@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-4.19.0.tgz#6ab6160af2705ece3935fca915eb00323eccf54e"
+  integrity sha512-HX7lvE6R/u3iJI8sbf85/7k3Vasdco4EWmwT1JTWpRVMl1KcphfmaYs7/nTDqrkbOo19VHOZQhnJCjUPd/O5QA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/element" "^6.18.0"
+    "@wordpress/element" "^6.19.0"
     clsx "^2.1.1"
 
 "@wordpress/priority-queue@^2.58.0":
@@ -4236,10 +4236,10 @@
     "@babel/runtime" "^7.16.0"
     requestidlecallback "^0.3.0"
 
-"@wordpress/priority-queue@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-3.18.0.tgz#794f34691f3cba26380db97c037ee202fb256a62"
-  integrity sha512-B8ZRIu91hnfs/O3P6sGW+sQThrMgF9qGzjIfqxPmKE8npn9wjAERxyrnyBy/pEdn1mI1gRHtaKqtuirPjBYmfw==
+"@wordpress/priority-queue@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-3.19.0.tgz#e4626c85d04068dfda7c85b5921765ff0bd63a1e"
+  integrity sha512-TJxjE42SrxrNjI4rWeRJ7mvfzJQ2fExCIDqAMZh9KoQNz0bLSCBY9CAJGWelYBE1t9CN9thU4WdTi5Htu7G41g==
   dependencies:
     "@babel/runtime" "7.25.7"
     requestidlecallback "^0.3.0"
@@ -4251,10 +4251,10 @@
   dependencies:
     "@babel/runtime" "^7.16.0"
 
-"@wordpress/private-apis@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/private-apis/-/private-apis-1.18.0.tgz#cf0bf1149d7bd0b9346d70565f4daa2a8348405d"
-  integrity sha512-yNt9cxdvIS60iWz/yy0qtsrZAYO8imkWA+xOYO7n5/N/kXchtCx4c6+XNMdX7ftyBrygOXJtsqkVoLUORPeKxw==
+"@wordpress/private-apis@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/private-apis/-/private-apis-1.19.0.tgz#d17358ca86383af3b3d17fce7bf61b5177814095"
+  integrity sha512-GHAUWgtz+vovGhuKFDEW5wlkyJcy15qHI5w3CB7YlC460fWI2f+H/JCbX9d8dPd3Lu91sgqbcn9jUjve9y+7/A==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -4268,33 +4268,33 @@
     is-promise "^4.0.0"
     rungen "^0.3.2"
 
-"@wordpress/redux-routine@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-5.18.0.tgz#81c030b46861d1e5cac065ecb0f54be89e753082"
-  integrity sha512-QlG5kKuUITzpVH3vrTuLiRgm9Zxe/QlG9xS/BYTiMorM9tPvwFbko244aDZbzghl4IkZub2ImucfzmxzoH7Ltg==
+"@wordpress/redux-routine@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-5.19.0.tgz#5aba63e1b56ef5939f4fb2a5daeb62cae731a7db"
+  integrity sha512-G4/m+HhNh5GujjrmmuE/u7c4j61vI9OVnuvGIXdqlzHZtrtlHM8DddANiBwj5X99wEc9sp3vgUrlVbgmM9wmlQ==
   dependencies:
     "@babel/runtime" "7.25.7"
     is-plain-object "^5.0.0"
     is-promise "^4.0.0"
     rungen "^0.3.2"
 
-"@wordpress/reusable-blocks@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/reusable-blocks/-/reusable-blocks-5.18.0.tgz#7ccb930a110a37e46727ca48a1b80fb044ba2669"
-  integrity sha512-Uz03XQJOhN4zR3uUi96HXebNDFfveO8AKLkHUUrkgpWJqe9mhOCweJle1303ZraY+H5vrPDjY642Z2Vykaw35w==
+"@wordpress/reusable-blocks@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/reusable-blocks/-/reusable-blocks-5.19.0.tgz#bfc33a30973ed2616d329fb0db95aa7f944ad293"
+  integrity sha512-k6D45wDlvxJEelAFJY9HRTYd/uSMDyp+d4m5oA/pUajhc6Ev0sTefK3mQmk+n+XgXotc+SaN6Pi7Br5t4TjhzQ==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/block-editor" "^14.13.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/core-data" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/icons" "^10.18.0"
-    "@wordpress/notices" "^5.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/block-editor" "^14.14.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/core-data" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/icons" "^10.19.0"
+    "@wordpress/notices" "^5.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
 
 "@wordpress/rich-text@^6.35.0":
   version "6.35.0"
@@ -4312,53 +4312,53 @@
     "@wordpress/keycodes" "^3.58.0"
     memize "^2.1.0"
 
-"@wordpress/rich-text@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-7.18.0.tgz#3557b75ba94250f72a53907e50c301cf404ab68c"
-  integrity sha512-pFFyjgbE2nQVYclKdttrBgWw5FUDubQdU8tQePjTSdMzLi6Lbod+A8FaK7wSsmfrzA3CFnMkLIhix8PHYyJ1sQ==
+"@wordpress/rich-text@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/rich-text/-/rich-text-7.19.0.tgz#580c1a6e0e30706ce4b85b442cc6cb289ede6d73"
+  integrity sha512-oRzMEsTKwCAj+4agz2G/RB2Md3UWVw4NblrwB91kreEftPFyIUCcRvWWqy+X9yWoy5uhwmNy2o6MhVQ4zTc3tA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/a11y" "^4.18.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/escape-html" "^3.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/keycodes" "^4.18.0"
+    "@wordpress/a11y" "^4.19.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/escape-html" "^3.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/keycodes" "^4.19.0"
     memize "^2.1.0"
 
-"@wordpress/router@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/router/-/router-1.18.0.tgz#f04c6875bf487d34d0fe6c9ed257593def3b6e25"
-  integrity sha512-waO2Uqps7n71S1UhUPjWwZObYBIrb6F9heTmwbAK+O0xUIgTkDcYO654CBAYbbv3RbAOZEZNdRHzfjW4i6yiPw==
+"@wordpress/router@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/router/-/router-1.19.0.tgz#22312080d32f79dc3df9663fd11e939f53d0304c"
+  integrity sha512-znhrxp2MI2OcFqCZfPESnz3LEOLxk+amNS9T7Mdv74pBzRF1A20dMV7Oy8TSljZiALcCVWkXGX6XiL1stRFmOg==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
     history "^5.3.0"
     route-recognizer "^0.3.4"
 
-"@wordpress/scripts@^30.11.0":
-  version "30.11.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/scripts/-/scripts-30.11.0.tgz#16c7af5526e4fd49f0fd087dbb4d2e05f48a9cb2"
-  integrity sha512-Iwu90e8ObphMIu4FqmzRNxWSUq5TtHvgG9/hzj1cIksfyD0PkDO8LHnzehMqpcTCVfADypOXmdMaBBWdkGEqXQ==
+"@wordpress/scripts@^30.12.0":
+  version "30.12.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/scripts/-/scripts-30.12.0.tgz#94b19dd74adf7786c60c7a46f6a0d8ca17430f03"
+  integrity sha512-+Gxdmf1HEOPrH4LaNeMH7Wngc894zAUt3h9ztlzR46pBiz80xGBJmD54fODC7bnevKbvNojhjWc2iOeM5nRHjQ==
   dependencies:
     "@babel/core" "7.25.7"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.11"
     "@svgr/webpack" "^8.0.1"
-    "@wordpress/babel-preset-default" "^8.18.0"
-    "@wordpress/browserslist-config" "^6.18.0"
-    "@wordpress/dependency-extraction-webpack-plugin" "^6.18.0"
-    "@wordpress/e2e-test-utils-playwright" "^1.18.0"
-    "@wordpress/eslint-plugin" "^22.4.0"
-    "@wordpress/jest-preset-default" "^12.18.0"
-    "@wordpress/npm-package-json-lint-config" "^5.18.0"
-    "@wordpress/postcss-plugins-preset" "^5.18.0"
-    "@wordpress/prettier-config" "^4.18.0"
-    "@wordpress/stylelint-config" "^23.10.0"
+    "@wordpress/babel-preset-default" "^8.19.0"
+    "@wordpress/browserslist-config" "^6.19.0"
+    "@wordpress/dependency-extraction-webpack-plugin" "^6.19.0"
+    "@wordpress/e2e-test-utils-playwright" "^1.19.0"
+    "@wordpress/eslint-plugin" "^22.5.0"
+    "@wordpress/jest-preset-default" "^12.19.0"
+    "@wordpress/npm-package-json-lint-config" "^5.19.0"
+    "@wordpress/postcss-plugins-preset" "^5.19.0"
+    "@wordpress/prettier-config" "^4.19.0"
+    "@wordpress/stylelint-config" "^23.11.0"
     adm-zip "^0.5.9"
     babel-jest "29.7.0"
     babel-loader "9.2.1"
@@ -4407,21 +4407,21 @@
     webpack-cli "^5.1.4"
     webpack-dev-server "^4.15.1"
 
-"@wordpress/server-side-render@^5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/server-side-render/-/server-side-render-5.18.0.tgz#856fda10c47edcd324d3069d1479ded9cf40dbbb"
-  integrity sha512-pFND5MDe0yJapXYAdd5DwY8QScCKCTTjk0vRS6MA7laGPOjH9nXUJ0Er+W2mh7EamPbDljhdXv8/l8iu9ZR7dg==
+"@wordpress/server-side-render@^5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/server-side-render/-/server-side-render-5.19.0.tgz#dac456cc3cfb7ab77c8f0e1f69c41b7b91394d70"
+  integrity sha512-o12DOVCTIQVHhE9K98znSWjXFMuMOkfE97KxzvQ8n0+K+tctFjmJOdnb5z5ekWLFHGFNmk6lFi+1aedcNvXKyw==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blocks" "^14.7.0"
-    "@wordpress/components" "^29.4.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/deprecated" "^4.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blocks" "^14.8.0"
+    "@wordpress/components" "^29.5.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/deprecated" "^4.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/url" "^4.19.0"
     fast-deep-equal "^3.1.3"
 
 "@wordpress/shortcode@^4.14.0":
@@ -4432,39 +4432,39 @@
     "@babel/runtime" "7.25.7"
     memize "^2.0.1"
 
-"@wordpress/shortcode@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-4.18.0.tgz#4c29f22b7ef2c68c47e457e8420cbc2aea100614"
-  integrity sha512-XMneQtxOvGmeqhQIURwtNN4otT/TGRhh87vxZuQYbAHQ5d+JeeFbLgferViZLWSNOJ2jioWvJGJIbIYshDrmhQ==
+"@wordpress/shortcode@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-4.19.0.tgz#1d820d8fa25696841c9accdce77bc4b9fbc6cb2a"
+  integrity sha512-MP88Im1krYh56s/AGLDhoP7hDEnxAFz8+M8dtCkEyLW3I9NUdScmRASAr2Rwitbm5hJvgU3XsxBrgpDLkOoO7g==
   dependencies:
     "@babel/runtime" "7.25.7"
     memize "^2.0.1"
 
-"@wordpress/style-engine@^2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/style-engine/-/style-engine-2.18.0.tgz#2436eef5e5d5d2ac3df9ee3bf26f4eaa9ca2b6b9"
-  integrity sha512-JyPfIe+Kt/R1Q4snab453S/Xumo8RwaTQviU0dYPawKP2R3Gd9uHFr+tVDBgJxYIJbAFfOMJdEiLkkOktfEAPQ==
+"@wordpress/style-engine@^2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/style-engine/-/style-engine-2.19.0.tgz#0b3063100fc77bd127dcd35150e618a906b1e97b"
+  integrity sha512-guwex680tGx2E4xkoWxRQ1Vr97MjXJQuz0fyeUyFnDOgg0r5MHPyM8ayoW9OEH4T2YjTT9/bMZDUE298DhZTsA==
   dependencies:
     "@babel/runtime" "7.25.7"
     change-case "^4.1.2"
 
-"@wordpress/stylelint-config@^23.10.0":
-  version "23.10.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/stylelint-config/-/stylelint-config-23.10.0.tgz#ee808b7bed485d26c3df78d72b90ccf39f70d2bc"
-  integrity sha512-e5NgU5UzZsYvM6+7s1pyAlhsQez/GqD3Eyq9tDwNE8Et51twe9rHSpTL9XbmSoZAMe5m3vGak6ctMwiqs/cj7g==
+"@wordpress/stylelint-config@^23.11.0":
+  version "23.11.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/stylelint-config/-/stylelint-config-23.11.0.tgz#2afb361c2b3b596b26e5a1b08fa7b966b51d65f5"
+  integrity sha512-osq25Nlcnwv4RJggYKnkfRbi6QDRI2O8PDMxVAvicL+JhxjtEqXKBwWaKNULHpc4aEWcGBaJtxJpzEE/7ZagBw==
   dependencies:
     "@stylistic/stylelint-plugin" "^3.0.1"
     stylelint-config-recommended "^14.0.1"
     stylelint-config-recommended-scss "^14.1.0"
 
-"@wordpress/sync@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/sync/-/sync-1.18.0.tgz#014cd1ae8ec35c572b82a12e9a10dadfeba657ca"
-  integrity sha512-LZaUH2iXSiISt5EPctKLS7cWgqU1PTFoElPqGA1Xt0/vxQXjNKYArXuciiqSkGj0tGo5jno9RYexBGNLWhvbUw==
+"@wordpress/sync@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/sync/-/sync-1.19.0.tgz#7dbcf6f4fff73f1a3cb134a99fb0f01063455ded"
+  integrity sha512-MUsDae9PHK+HI8jwbsuZm6/oY6E2DwBehG8fGYWVANLLog+1jS31WJ37V10lzd0MZWa+z4g8u5ZJGW7EKEmnEw==
   dependencies:
     "@babel/runtime" "7.25.7"
     "@types/simple-peer" "^9.11.5"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/url" "^4.19.0"
     import-locals "^2.0.0"
     lib0 "^0.2.42"
     simple-peer "^9.11.0"
@@ -4473,10 +4473,10 @@
     y-webrtc "~10.2.5"
     yjs "~13.6.6"
 
-"@wordpress/token-list@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-3.18.0.tgz#df1ecb8c704b54bab1a6938272fd5c77cde2c1bc"
-  integrity sha512-90AxsuNkAV22O2EahlCS98teraMGdQGG5LZqIgpQMqNoBGTfs7/F6Jgq1xBypDz+Fh7FVNNkdF7ANGVYH+b26g==
+"@wordpress/token-list@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/token-list/-/token-list-3.19.0.tgz#f4efba7441793d5b1b96cdc5ab6df10716a47c98"
+  integrity sha512-V0YF0vv/UdM1LJ32iKCJpqtzJrTHJ4ynMzCV1BdDWBTDp7chQGJcXuX7aTBz8Z/lDO48ycwOrRoK9+LWoEglBg==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -4488,64 +4488,64 @@
     "@babel/runtime" "^7.16.0"
     "@wordpress/is-shallow-equal" "^4.58.0"
 
-"@wordpress/undo-manager@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/undo-manager/-/undo-manager-1.18.0.tgz#5ec19770e1faac98c9a7740e13b32ebaf260af77"
-  integrity sha512-OmOCihoOzWgyhs+6BFJJcGxgPby8sd1y0zlW+PuGOeNxtxLVa9Q4cGDcUE0++OcWk9b/0S0l4XrzwKTC4eyiQw==
+"@wordpress/undo-manager@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/undo-manager/-/undo-manager-1.19.0.tgz#6c8a855800b1974f392c36068cea5859211b0cfe"
+  integrity sha512-R6De7iFfR12IIi3euA4UPzz+IRwpVM5soTZezK24enNkvqxLJtcoqpPimlnzO/DLLSyFRI994jtznfRT02fIYA==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/is-shallow-equal" "^5.18.0"
+    "@wordpress/is-shallow-equal" "^5.19.0"
 
-"@wordpress/upload-media@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/upload-media/-/upload-media-0.3.0.tgz#3e1835da038a6b13ff4e5d8a8b6821f70da642d2"
-  integrity sha512-tX7R4UKigkfe9m9BlS/jVJ9uOIrHGPJf6fTScqhCgmRiXKMymwtPFS+3OP9yCQe4Tz1bNyhhzPBhaFWFI7WJ1w==
+"@wordpress/upload-media@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/upload-media/-/upload-media-0.4.0.tgz#f4669876bf03c862caf10297d363b417c6d6311a"
+  integrity sha512-UQ6r3ecd1TRbeSI/DRMNNvLLEe9iD5tYw2ywVzDQcq49+epeGKWK6gyPY0zT8ypTZkY8NNSTfDgLD+iYzX60ug==
   dependencies:
     "@babel/runtime" "7.25.7"
     "@shopify/web-worker" "^6.4.0"
-    "@wordpress/api-fetch" "^7.18.0"
-    "@wordpress/blob" "^4.18.0"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
-    "@wordpress/i18n" "^5.18.0"
-    "@wordpress/preferences" "^4.18.0"
-    "@wordpress/private-apis" "^1.18.0"
-    "@wordpress/url" "^4.18.0"
+    "@wordpress/api-fetch" "^7.19.0"
+    "@wordpress/blob" "^4.19.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
+    "@wordpress/i18n" "^5.19.0"
+    "@wordpress/preferences" "^4.19.0"
+    "@wordpress/private-apis" "^1.19.0"
+    "@wordpress/url" "^4.19.0"
     uuid "^9.0.1"
 
-"@wordpress/url@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-4.18.0.tgz#2ff53ceb5e5cecab95f2fb51d32152b707564da4"
-  integrity sha512-Jr1O9NjNKQuWRIBzc0G/aiHt54vXkCJ50JJiKAAFnz6yTE6XVoPvxDG3nidGAThNWQgZ1UykY6Zir+XrQPHBtw==
+"@wordpress/url@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-4.19.0.tgz#4ed03bed0244c4f33b85f7ded95da232c5357b78"
+  integrity sha512-j/bjoEoCoO9/0CbT0oyzO7nFuJqL3WeFCIrHw8JIlnHG7xNoj5rtDma01fdPyRHV6Xt6WXNkFnjnGmBQvXdCQg==
   dependencies:
     "@babel/runtime" "7.25.7"
     remove-accents "^0.5.0"
 
-"@wordpress/viewport@^6.18.0":
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/viewport/-/viewport-6.18.0.tgz#4a605145e147dabfd1e7cc4a02491391e80b2d25"
-  integrity sha512-MokrS9MiDh6g4Vzl0MSU1LKuTBLcydZjvryYjLnfd1BqE0DGNBOMtCe1L7RwXEkbxbhv4UCc7xZ5G0CUeOaGDw==
+"@wordpress/viewport@^6.19.0":
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/viewport/-/viewport-6.19.0.tgz#31e6dafbb5213f5e8b37cc59fd672ea2ddc4ad06"
+  integrity sha512-tANjhNysCHBmxkbLnwID6Cf+QtF4b6VMuiY1Hx80Y97I/vXxcBNzIyFEzbt/lOxl+hipJgxzHq2u1y8tbI0kYg==
   dependencies:
     "@babel/runtime" "7.25.7"
-    "@wordpress/compose" "^7.18.0"
-    "@wordpress/data" "^10.18.0"
-    "@wordpress/element" "^6.18.0"
+    "@wordpress/compose" "^7.19.0"
+    "@wordpress/data" "^10.19.0"
+    "@wordpress/element" "^6.19.0"
 
 "@wordpress/warning@^2.58.0":
   version "2.58.0"
   resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-2.58.0.tgz#1f2f2cd10302daa4e6d391037a49f875e8d12fcc"
   integrity sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==
 
-"@wordpress/warning@^3.18.0":
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-3.18.0.tgz#00b4e01b0b734223413be56ee8bf1e5746cd14d7"
-  integrity sha512-Y58A1D38PJbQzFZXokL+4rACzs5Vp5cZMZc/9J+QOYStJdy/xEDQttbhte2P7kq0yF3EUZDC0QnG8RsIV09WSQ==
+"@wordpress/warning@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-3.19.0.tgz#54852632bc6ef6b5840aae67db3f169fe21acb09"
+  integrity sha512-hxRGkyKC+Ey7fPeiIX59gtYxYHNo2wTbvC3eqMmRI6ywTnJgHMwdx4Tih6Y/F3KimZU6t5Gm9+UWsLhUujOHDw==
 
-"@wordpress/wordcount@^4.18.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/wordcount/-/wordcount-4.18.0.tgz#a0c8862844f95ca30c8060d94e9e02531e325db3"
-  integrity sha512-JNflIJoeuLDjzK2k9JdHcY+RhJ9cr0iHO8lgtVOTYSqF5tGpk1+QiA8Y/cyONJNzBbUO48C/G+gEsRk5fyXNhA==
+"@wordpress/wordcount@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/wordcount/-/wordcount-4.19.0.tgz#a12703416bb0d89a28cd740979622d419df3c0e6"
+  integrity sha512-7QJLe36sfBodDy1cL7LY4WCzpglEmbTBwmreSydRdwCPYBGstWtdG3PnZW/Cf5rM6O8XP3yUYtfiMmhD21yb3Q==
   dependencies:
     "@babel/runtime" "7.25.7"
 
@@ -12896,10 +12896,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.7.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+typescript@^5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Enhances the logged out commenting experience by showing an avatar for the email address that is entered. This avatar can be used to open the quick editor, allowing direct modification of the account from the comments page.

It is enabled from the Gravatar Enhanced section of the discussion page:

![image](https://github.com/user-attachments/assets/d3e097b2-72d8-4584-a9d2-8266a3dc16f3)

When enabled it re-arranges the comment form so that email is before name:

![image](https://github.com/user-attachments/assets/ba47a3fe-6839-421d-8517-2aedff283588)

When an email is entered we then show the Gravatar profile inline in the field:

![image](https://github.com/user-attachments/assets/bbfc9264-c09c-4340-92a6-f22d60cb0d12)

If the user hasn't already entered a name and URL in the comment form these will be pre-filled from the Gravatar profile.

The icon will slide into place and briefly pulsate:

https://github.com/user-attachments/assets/b86080ef-aff6-4174-97df-7fcc88ee85b9

Clicking the icon will open up the Gravatar quick editor.

This will require https://github.com/Automattic/gravatar/pull/166 to be included in order to not trigger the hovercard when opening the quick editor.

# Caveats

The code should adjust to most themes but some are problematic. I've confirmed it working with all WordPress themes except Twenty Fifteen, which does it's own input field thing.

# Testing

- `yarn build`
- Go to post as a logged out user and enter an email address
- Confirm an avatar is shown in the email field. Clicking this should open the quick editor