### PR TITLE
Pass commenter name when displaying 'initials' avatar

### DIFF
--- a/classes/avatar/class-avatar-id.php
+++ b/classes/avatar/class-avatar-id.php
@@ -12,7 +12,7 @@ use WP_Comment;
  *   size: number,
  *   height: number,
  *   width: number,
- *   default: string,
+ *   default?: string,
  *   force_default: boolean,
  *   rating: string,
  *   scheme: string,

--- a/classes/avatar/class-avatar.php
+++ b/classes/avatar/class-avatar.php
@@ -128,6 +128,11 @@ class Avatar {
 			return $url;
 		}
 
+		// If the default is set to 'initials' and we have a comment, use the comment author name
+		if ( $args['default'] === 'initials' && $id_or_email instanceof \WP_Comment ) {
+			$url .= '&name=' . rawurlencode( $id_or_email->comment_author );
+		}
+
 		$user = new AvatarId( $id_or_email, $args );
 		$new_url = preg_replace( '@avatar/([a-f0-9]+)@', 'avatar/' . $user->get_hash(), $url );
 		return (string) $new_url;

--- a/classes/avatar/class-avatar.php
+++ b/classes/avatar/class-avatar.php
@@ -129,7 +129,7 @@ class Avatar {
 		}
 
 		// If the default is set to 'initials' and we have a comment, use the comment author name
-		if ( $args['default'] === 'initials' && $id_or_email instanceof \WP_Comment ) {
+		if ( isset( $args['default'] ) && $args['default'] === 'initials' && $id_or_email instanceof \WP_Comment ) {
 			$url .= '&name=' . rawurlencode( $id_or_email->comment_author );
 		}
 

--- a/gravatar-enhanced.php
+++ b/gravatar-enhanced.php
@@ -4,7 +4,7 @@ Plugin Name: Gravatar Enhanced
 Plugin URI: https://wordpress.org/extend/plugins/gravatar-enhanced/
 Description: Enhanced functionality for Gravatar-ifying your WordPress site. Once you've enabled the plugin, go to the "Avatars" section on the <a href="options-discussion.php">Discussion Settings page</a> to get started.
 Author: Automattic
-Version: 0.8.0
+Version: 0.8.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Requires at least: 6.6
@@ -12,7 +12,7 @@ Requires PHP: 7.4
 */
 
 define( 'GRAVATAR_ENHANCED_PLUGIN_FILE', __FILE__ );
-define( 'GRAVATAR_ENHANCED_VERSION', '0.8.0' );
+define( 'GRAVATAR_ENHANCED_VERSION', '0.8.1' );
 
 if ( version_compare( phpversion(), '7.4' ) >= 0 ) {
 	require_once __DIR__ . '/classes/class-plugin.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gravatar-enhanced",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Gravatar Enhanced WordPress plugin",
 	"scripts": {
 		"start": "wp-scripts start",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
 		"@types/wordpress__blocks": "^12.5.17",
 		"@wordpress/eslint-plugin": "^22.4.0",
 		"@wordpress/scripts": "^30.11.0",
-		"npm-check-updates": "^17.1.14",
+		"npm-check-updates": "^17.1.15",
 		"release-it": "^18.1.2",
 		"typescript": "^5.7.3"
 	},
 	"dependencies": {
-		"@gravatar-com/hovercards": "^0.10.4",
+		"@gravatar-com/hovercards": "^0.10.5",
 		"@gravatar-com/quick-editor": "^0.6.0",
 		"@wordpress/editor": "^14.18.0",
 		"@wordpress/url": "^4.18.0",

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 
 = 0.9.0 =
 * Add more Gravatar patterns
+* Pass comment initials when using initials avatar
 * Fix empty profile blocks are rendered in the frontend view
 
 = 0.8.0 =

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,10 +1453,10 @@
   dependencies:
     tslib "2"
 
-"@gravatar-com/hovercards@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.10.4.tgz#9fc49fb32110e949a6e8af394eefc6d0ddf7e2d7"
-  integrity sha512-Ldqrffcxaywq2vxu/QWmKDfbsSbGI8iHPNeyGJNFgyXHAi6uSPPXQhS17+wVMUKBPs/reMGfxcrVO/hnAPXhDQ==
+"@gravatar-com/hovercards@^0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.10.5.tgz#f22eb8d6460c8256e81b7437d8785b5c46a190eb"
+  integrity sha512-NGgCLhdQbM8amUy4PtRJng+NhgjOC8o/tn4up3Hqp1lG8PEhytOXmV7M9dyDPYagtN6o7/DYrEf/kanv375lCg==
 
 "@gravatar-com/quick-editor@^0.6.0":
   version "0.6.0"
@@ -10069,10 +10069,10 @@ npm-bundled@^1.1.1:
   dependencies:
     npm-normalize-package-bin "^1.0.1"
 
-npm-check-updates@^17.1.14:
-  version "17.1.14"
-  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-17.1.14.tgz#68285d98b296656bf7a8f747123c51d1adbdbb2b"
-  integrity sha512-dr4bXIxETubLI1tFGeock5hN8yVjahvaVpx+lPO4/O2md3zJuxB7FgH3MIoTvQSCgsgkIRpe0skti01IEAA5tA==
+npm-check-updates@^17.1.15:
+  version "17.1.15"
+  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-17.1.15.tgz#3e5734f5acf91de1c4ef3cd4ac460172d9195c99"
+  integrity sha512-miATvKu5rjec/1wxc5TGDjpsucgtCHwRVZorZpDkS6NzdWXfnUWlN4abZddWb7XSijAuBNzzYglIdTm9SbgMVg==
 
 npm-normalize-package-bin@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Pass the commenter name when the default avatar is 'initials'.

# Testing

- On discussions page set the default avatar to 'initials' and 'force default avatar'
- View a post with comments and check the avatar shows the commenter initials