### PR TITLE
Fix QE integration with some plugins

### DIFF
--- a/classes/quick-editor/class-quick-editor.php
+++ b/classes/quick-editor/class-quick-editor.php
@@ -49,17 +49,20 @@ class QuickEditor {
 			return;
 		}
 
+		$personal_options = __( 'Personal Options' );
+
 		// Move user information to top
-		preg_match( '@<h2>(.*?)</table>@s', $profile_page, $profile_details );
+		preg_match( '@<h2>' . $personal_options . '</h2>(.*?)</table>@s', $profile_page, $profile_details );
 		preg_match( '@<tr class="user-description-wrap.*?</tr>@s', $profile_page, $user_description );
 
 		// Remove the personal options
-		$profile_page = (string) preg_replace( '@<h2>.*?</table>@s', '', $profile_page, 1 );
+		$profile_page = (string) preg_replace( '@<h2>' . $personal_options . '</h2>.*?</table>@s', '', $profile_page, 1 );
 
 		// Remove the bio
 		$profile_page = (string) preg_replace( '@<tr class="user-description-wrap.*?</tr>@s', '', $profile_page, 1 );
 
 		if ( ! isset( $profile_details[0] ) || ! isset( $user_description[0] ) ) {
+			echo $profile_page;
 			return;
 		}
 

--- a/classes/quick-editor/class-quick-editor.php
+++ b/classes/quick-editor/class-quick-editor.php
@@ -49,7 +49,7 @@ class QuickEditor {
 			return;
 		}
 
-		$personal_options = __( 'Personal Options' );
+		$personal_options = preg_quote( __( 'Personal Options' ), '@' );
 
 		// Move user information to top
 		preg_match( '@<h2>' . $personal_options . '</h2>(.*?)</table>@s', $profile_page, $profile_details );

--- a/classes/woocommerce/class-admin-customers.php
+++ b/classes/woocommerce/class-admin-customers.php
@@ -51,7 +51,7 @@ class AdminCustomers {
 			$asset_file = dirname( GRAVATAR_ENHANCED_PLUGIN_FILE ) . '/build/wc-admin-customers.asset.php';
 			$assets     = file_exists( $asset_file ) ? require $asset_file : [
 				'dependencies' => [],
-				'version'      => time()
+				'version'      => time(),
 			];
 
 			wp_enqueue_script(

--- a/classes/woocommerce/class-my-account.php
+++ b/classes/woocommerce/class-my-account.php
@@ -119,16 +119,16 @@ class MyAccount {
 		$display_name = esc_html( $current_user->display_name );
 
 		$html = <<<HTML
-        <div class="woocommerce-account-gravatar">
-            <div class="woocommerce-account-gravatar__avatar-wrapper">
-                $avatar
-                <div class="woocommerce-account-gravatar__edit-wrapper">
-                    <a class="woocommerce-account-gravatar__edit">$edit_text</a>
-                </div>
-            </div>
-            <span class="woocommerce-account-gravatar__display-name">$display_name</span>
-        </div>
-        HTML;
+		<div class="woocommerce-account-gravatar">
+			<div class="woocommerce-account-gravatar__avatar-wrapper">
+				$avatar
+				<div class="woocommerce-account-gravatar__edit-wrapper">
+					<a class="woocommerce-account-gravatar__edit">$edit_text</a>
+				</div>
+			</div>
+			<span class="woocommerce-account-gravatar__display-name">$display_name</span>
+		</div>
+		HTML;
 
 		return $html;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,8 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 * Pass comment initials when using initials avatar
 * Fix empty profile blocks are rendered in the frontend view
 * Replace the Gravatar profile's column block with a group block
+* Improve compatibility with quick editor and other plugins
+* Fix quick editor language support for Taiwanese
 
 = 0.8.0 =
 * Add the first Gravatar block pattern


### PR DESCRIPTION
We do a lot of regex manipulation on the user page in order to move things around and insert the quick editor. Some other plugins, such as WooCommerce, also insert data onto this page and it breaks the regex used here.

This PR makes the regex more specific.

# Testing

- Install & activate WooCommerce
- Go to user profile page and edit another user and confirm the page displays correctly, and the quick editor is available. It should not appear in the 'help' section (top right dropdown thing).
- Change site language and repeat the above. The profile page should work the same regardless of language