### PR TITLE
Add filter used as whitelist of modules to load.

### DIFF
--- a/classes/analytics/class-analytics.php
+++ b/classes/analytics/class-analytics.php
@@ -2,10 +2,12 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Analytics;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
 require_once __DIR__ . '/class-analytics-options.php';
 require_once __DIR__ . '/class-analytics-preferences.php';
 
-class Analytics {
+class Analytics implements Module {
 	const OPTION_ANALYTICS = 'gravatar_analytics';
 
 	/**
@@ -98,4 +100,9 @@ class Analytics {
 		// phpcs:ignore
 		echo $js;
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/avatar/class-avatar.php
+++ b/classes/avatar/class-avatar.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Avatar;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
 require_once __DIR__ . '/class-avatar-id.php';
 require_once __DIR__ . '/class-avatar-options.php';
 require_once __DIR__ . '/class-avatar-preferences.php';
@@ -10,7 +12,7 @@ require_once __DIR__ . '/class-avatar-preferences.php';
  * @phpstan-import-type WPAvatarId from AvatarId
  * @phpstan-import-type WPAvatar from AvatarId
  */
-class Avatar {
+class Avatar implements Module {
 	const FILTER_HASH_ENCODING = 'gravatar_hash_encoding';
 	const FILTER_REFERRER_POLICY = 'gravatar_referrer_policy';
 
@@ -137,4 +139,9 @@ class Avatar {
 		$new_url = preg_replace( '@avatar/([a-f0-9]+)@', 'avatar/' . $user->get_hash(), $url );
 		return (string) $new_url;
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/block/class-block.php
+++ b/classes/block/class-block.php
@@ -2,11 +2,13 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Block;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-class Block {
+class Block implements Module {
 	/**
 	 * @return void
 	 */
@@ -31,4 +33,6 @@ class Block {
 		register_block_type( $block_dir . '/editor-blocks/paragraph' );
 		register_block_type( $block_dir . '/editor-blocks/link' );
 	}
+
+	public function uninstall() {}
 }

--- a/classes/class-module.php
+++ b/classes/class-module.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced;
+
+interface Module {
+
+	/**
+	 * Initialize the module.
+	 *
+	 * @return void
+	 */
+	public function init();
+
+	/**
+	 * Uninstall the module.
+	 *
+	 * @return void
+	 */
+	public function uninstall();
+
+}

--- a/classes/class-module.php
+++ b/classes/class-module.php
@@ -17,5 +17,4 @@ interface Module {
 	 * @return void
 	 */
 	public function uninstall();
-
 }

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -135,7 +135,7 @@ class Plugin {
 		}
 
 		// Handles the discussions settings page
-		$this->discussions = new Options\DiscussionsPage( $this->auto_options, $this->lazy_options, $enabled_modules = array_keys($this->modules) );
+		$this->discussions = new Options\DiscussionsPage( $this->auto_options, $this->lazy_options, array_keys( $this->modules ) );
 
 		// Ensure the options always exist. We don't need data saved in it as this is provided by the defaults
 		if ( get_option( self::OPTION_NAME_AUTO, null ) === null ) {

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced;
 
+require_once __DIR__ . '/class-module.php';
 require_once __DIR__ . '/options/class-discussions.php';
 require_once __DIR__ . '/email/class-email.php';
 require_once __DIR__ . '/hovercards/class-hovercards.php';

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -129,9 +129,9 @@ class Plugin {
 			'wc_my_account' => $this->wc_my_account,
 			'oembed' => $this->oembed,
 		];
-		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null);
-		if ( is_array($modules_whitelist) ) {
-			$this->modules = array_intersect_key($this->modules, array_flip($modules_whitelist));
+		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null );
+		if ( is_array( $modules_whitelist ) ) {
+			$this->modules = array_intersect_key( $this->modules, array_flip( $modules_whitelist ) );
 		}
 
 		// Handles the discussions settings page
@@ -149,7 +149,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
-		foreach( $this->modules as $module ) {
+		foreach ( $this->modules as $module ) {
 			$module->init();
 		}
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -89,6 +89,11 @@ class Plugin {
 	 */
 	private $oembed;
 
+	/**
+	 * @var Module[]
+	 */
+	private $modules;
+
 	public function __construct() {
 		$this->auto_options = new Options\SavedOptions( self::OPTION_NAME_AUTO, true );
 		$this->lazy_options = new Options\SavedOptions( self::OPTION_NAME_LAZY, false );
@@ -96,9 +101,6 @@ class Plugin {
 		// Migrate old options. We're only interested in email settings. This will only run once.
 		$migrator = new Options\Migrate();
 		$migrator->maybe_migrate( $this->lazy_options, self::OPTION_NAME_LAZY );
-
-		// Handles the discussions settings page
-		$this->discussions = new Options\DiscussionsPage( $this->auto_options, $this->lazy_options );
 
 		// Modules
 		$this->email = new Email\EmailNotification( new Email\Preferences( $this->lazy_options ) );
@@ -112,6 +114,27 @@ class Plugin {
 		$this->wc_admin_customers = new Woocommerce\AdminCustomers();
 		$this->wc_my_account = new Woocommerce\MyAccount();
 		$this->oembed = new OEmbed\OEmbed();
+		// Collect all modules and filter them based on the whitelist if available.
+		$this->modules = [
+			'email' => $this->email,
+			'hovercards' => $this->hovercards,
+			'avatar' => $this->avatar,
+			'proxy' => $this->proxy,
+			'quick_editor' => $this->quick_editor,
+			'analytics' => $this->analytics,
+			'block' => $this->block,
+			'patterns' => $this->patterns,
+			'wc_admin_customers' => $this->wc_admin_customers,
+			'wc_my_account' => $this->wc_my_account,
+			'oembed' => $this->oembed,
+		];
+		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null);
+		if ( is_array($modules_whitelist) ) {
+			$this->modules = array_intersect_key($this->modules, array_flip($modules_whitelist));
+		}
+
+		// Handles the discussions settings page
+		$this->discussions = new Options\DiscussionsPage( $this->auto_options, $this->lazy_options, $enabled_modules = array_keys($this->modules) );
 
 		// Ensure the options always exist. We don't need data saved in it as this is provided by the defaults
 		if ( get_option( self::OPTION_NAME_AUTO, null ) === null ) {
@@ -120,23 +143,17 @@ class Plugin {
 	}
 
 	/**
-	 * Start the plugin
+	 * Start the plugin by initializing all the enabled modules.
 	 *
 	 * @return void
 	 */
 	public function init() {
-		$this->email->init();
-		$this->hovercards->init();
-		$this->avatar->init();
-		$this->proxy->init();
-		$this->quick_editor->init();
+		foreach( $this->modules as $module ) {
+			$module->init();
+		}
+
+		// Initialize discussions settings.
 		$this->discussions->init();
-		$this->analytics->init();
-		$this->block->init();
-		$this->patterns->init();
-		$this->wc_admin_customers->init();
-		$this->wc_my_account->init();
-		$this->oembed->init();
 	}
 
 	/**
@@ -145,11 +162,15 @@ class Plugin {
 	 * @return void
 	 */
 	public function uninstall() {
-		$this->email->uninstall();
-		$this->hovercards->uninstall();
+
+		// Uninstall all enabled modules.
+		foreach ( $this->modules as $module ) {
+			$module->uninstall();
+		}
+
+		// Uninstall discussion settings options.
 		$this->auto_options->uninstall();
 		$this->lazy_options->uninstall();
-		$this->patterns->uninstall();
 
 		// Just in case, flush the cache
 		wp_cache_flush();

--- a/classes/email/class-email.php
+++ b/classes/email/class-email.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Email;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
 use WP_Http;
 use WP_Comment;
 use WP_Post;
@@ -9,7 +10,7 @@ use WP_Post;
 require_once __DIR__ . '/class-email-options.php';
 require_once __DIR__ . '/class-email-preferences.php';
 
-class EmailNotification {
+class EmailNotification implements Module {
 	/**
 	 * @var Preferences
 	 */

--- a/classes/hovercards/class-hovercards.php
+++ b/classes/hovercards/class-hovercards.php
@@ -11,6 +11,11 @@ class Hovercards implements Module {
 	const OPTION_HOVERCARDS = 'gravatar_hovercards';
 
 	/**
+	 * @var string
+	 */
+	const FILTER_GRAVATAR_HOVERCARDS_MODULE_ENABLED = 'gravatar_enhanced_hovercards_module_enabled';
+
+	/**
 	 * @return void
 	 */
 	public function init() {
@@ -116,6 +121,11 @@ class Hovercards implements Module {
 	 * @return bool
 	 */
 	private function is_module_disabled() {
+		// Check if module is manually disabled by the filter.
+		if ( ! apply_filters( self::FILTER_GRAVATAR_HOVERCARDS_MODULE_ENABLED, true ) ) {
+			return true; // Disabled by filter.
+		}
+
 		// Check if Jetpack is active and has the Gravatar Hovercards module enabled.
 		if ( class_exists( '\Jetpack' ) && \Jetpack::is_module_active( 'gravatar-hovercards' ) ) {
 			return true; // Disabled due to Jetpack Gravatar Hovercards module.

--- a/classes/hovercards/class-hovercards.php
+++ b/classes/hovercards/class-hovercards.php
@@ -2,16 +2,13 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Hovercards;
 
-class Hovercards {
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
+class Hovercards implements Module {
 	/**
 	 * @var string
 	 */
 	const OPTION_HOVERCARDS = 'gravatar_hovercards';
-
-	/**
-	 * @var string
-	 */
-	const FILTER_GRAVATAR_HOVERCARDS_MODULE_ENABLED = 'gravatar_enhanced_hovercards_module_enabled';
 
 	/**
 	 * @return void
@@ -119,11 +116,6 @@ class Hovercards {
 	 * @return bool
 	 */
 	private function is_module_disabled() {
-		// Check if module is manually disabled by the filter.
-		if ( ! apply_filters( self::FILTER_GRAVATAR_HOVERCARDS_MODULE_ENABLED, true ) ) {
-			return true; // Disabled by filter.
-		}
-
 		// Check if Jetpack is active and has the Gravatar Hovercards module enabled.
 		if ( class_exists( '\Jetpack' ) && \Jetpack::is_module_active( 'gravatar-hovercards' ) ) {
 			return true; // Disabled due to Jetpack Gravatar Hovercards module.

--- a/classes/oembed/class-oembed.php
+++ b/classes/oembed/class-oembed.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\OEmbed;
 
-class OEmbed {
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
+class OEmbed implements Module {
 	private const API_ENDPOINT = 'https://api.gravatar.com/v3/oembed';
 
 	/**
@@ -20,4 +22,9 @@ class OEmbed {
 	public function register_oembed_provider() {
 		wp_oembed_add_provider( '/^https?:\/\/((www|[a-z]{2}(-[A-Z]{2})?)\.)?gravatar\.com\/([a-zA-Z0-9]+)\/?$/', self::API_ENDPOINT, true );
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -28,7 +28,7 @@ class DiscussionsPage {
 	/**
 	 * @var string[]
 	 */
-	private array $enabled_modules;
+	private $enabled_modules;
 
 	/**
 	 * @param SavedOptions $auto_options

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -26,12 +26,19 @@ class DiscussionsPage {
 	private $lazy_options;
 
 	/**
+	 * @var string[]
+	 */
+	private array $enabled_modules;
+
+	/**
 	 * @param SavedOptions $auto_options
 	 * @param SavedOptions $lazy_options
+	 * @param string[] $enabled_modules The enabled modules, as defined in `class-plugin.php`.
 	 */
-	public function __construct( $auto_options, $lazy_options ) {
+	public function __construct( $auto_options, $lazy_options, $enabled_modules ) {
 		$this->auto_options = $auto_options;
 		$this->lazy_options = $lazy_options;
+		$this->enabled_modules = $enabled_modules;
 	}
 
 	/**
@@ -49,37 +56,45 @@ class DiscussionsPage {
 	public function admin_init() {
 		add_action( 'load-options.php', [ $this, 'save_settings' ] );
 
-		add_settings_field(
-			'avatar-options',
-			__( 'Avatar Options', 'gravatar-enhanced' ),
-			[ $this, 'display_avatar_settings' ],
-			'discussion',
-			'avatars'
-		);
+		if ( in_array( 'avatar', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'avatar-options',
+				__( 'Avatar Options', 'gravatar-enhanced' ),
+				[ $this, 'display_avatar_settings' ],
+				'discussion',
+				'avatars'
+			);
+		}
 
-		add_settings_field(
-			'email-options',
-			__( 'Invitation', 'gravatar-enhanced' ),
-			[ $this, 'display_email_settings' ],
-			'discussion',
-			'avatars'
-		);
+		if ( in_array( 'email', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'email-options',
+				__( 'Invitation', 'gravatar-enhanced' ),
+				[ $this, 'display_email_settings' ],
+				'discussion',
+				'avatars'
+			);
+		}
 
-		add_settings_field(
-			'proxy-options',
-			__( 'Avatar Proxy', 'gravatar-enhanced' ),
-			[ $this, 'display_proxy_settings' ],
-			'discussion',
-			'avatars'
-		);
+		if ( in_array( 'proxy', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'proxy-options',
+				__( 'Avatar Proxy', 'gravatar-enhanced' ),
+				[ $this, 'display_proxy_settings' ],
+				'discussion',
+				'avatars'
+			);
+		}
 
-		add_settings_field(
-			'analytics-options',
-			__( 'Anonymous Analytics', 'gravatar-enhanced' ),
-			[ $this, 'display_analytics_settings' ],
-			'discussion',
-			'avatars'
-		);
+		if ( in_array( 'analytics', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'analytics-options',
+				__( 'Anonymous Analytics', 'gravatar-enhanced' ),
+				[ $this, 'display_analytics_settings' ],
+				'discussion',
+				'avatars'
+			);
+		}
 	}
 
 	/**
@@ -226,18 +241,26 @@ class DiscussionsPage {
 			return;
 		}
 
-		$avatar_preferences = $this->get_avatar_preferences();
-		$proxy_preferences = $this->get_proxy_preferences();
-		$analytics_preferences = $this->get_analytics_preferences();
-
-		$this->auto_options->update( $avatar_preferences );
-		$this->auto_options->update( $proxy_preferences );
-		$this->auto_options->update( $analytics_preferences );
+		// Handle auto options.
+		if ( in_array('avatar', $this->enabled_modules, true) ) {
+			$avatar_preferences = $this->get_avatar_preferences();
+			$this->auto_options->update( $avatar_preferences );
+		}
+		if ( in_array( 'proxy', $this->enabled_modules, true ) ) {
+			$proxy_preferences = $this->get_proxy_preferences();
+			$this->auto_options->update( $proxy_preferences );
+		}
+		if ( in_array( 'analytics', $this->enabled_modules, true ) ) {
+			$analytics_preferences = $this->get_analytics_preferences();
+			$this->auto_options->update( $analytics_preferences );
+		}
 		$this->auto_options->save();
 
-		$email_preferences = $this->get_email_preferences();
-
-		$this->lazy_options->update( $email_preferences );
+		// Handle lazy options.
+		if ( in_array( 'email', $this->enabled_modules, true ) ) {
+			$email_preferences = $this->get_email_preferences();
+			$this->lazy_options->update( $email_preferences );
+		}
 		$this->lazy_options->save();
 	}
 

--- a/classes/patterns/class-patterns.php
+++ b/classes/patterns/class-patterns.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Patterns;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
 /**
  * How to add a new pattern:
  *
@@ -9,7 +11,7 @@ namespace Automattic\Gravatar\GravatarEnhanced\Patterns;
  * 2. Create a file in `classes/patterns` named `type-number.php` (e.g., `grid-pattern-1.php`) containing the pattern content
  * 3. Update the block pattern settings in `register_patterns` if needed
  */
-class Patterns {
+class Patterns implements Module {
 	/**
 	 * Patterns.
 	 *

--- a/classes/proxy/class-proxy.php
+++ b/classes/proxy/class-proxy.php
@@ -7,9 +7,10 @@ require_once __DIR__ . '/class-hash.php';
 require_once __DIR__ . '/class-proxy-options.php';
 require_once __DIR__ . '/class-proxy-preferences.php';
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
 use WP_Error;
 
-class Proxy {
+class Proxy implements Module {
 	/**
 	 * @var Options
 	 */
@@ -202,4 +203,9 @@ class Proxy {
 
 		return new LocalAvatarHash( $url );
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/quick-editor/class-quick-editor.php
+++ b/classes/quick-editor/class-quick-editor.php
@@ -2,9 +2,10 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\QuickEditor;
 
+use Automattic\Gravatar\GravatarEnhanced\Module;
 use WP_User;
 
-class QuickEditor {
+class QuickEditor implements Module {
 	/**
 	 * @return void
 	 */
@@ -246,4 +247,9 @@ HTML;
 
 		return get_userdata( $user_id );
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/woocommerce/class-admin-customers.php
+++ b/classes/woocommerce/class-admin-customers.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Woocommerce;
 
-class AdminCustomers {
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
+class AdminCustomers implements Module {
 	/**
 	 * @var string
 	 */
@@ -70,4 +72,9 @@ class AdminCustomers {
 			);
 		}
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }

--- a/classes/woocommerce/class-my-account.php
+++ b/classes/woocommerce/class-my-account.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\Gravatar\GravatarEnhanced\Woocommerce;
 
-class MyAccount {
+use Automattic\Gravatar\GravatarEnhanced\Module;
+
+class MyAccount implements Module {
 	/**
 	 * @var string
 	 */
@@ -132,4 +134,9 @@ class MyAccount {
 
 		return $html;
 	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
 }


### PR DESCRIPTION
Fixes #75

## Description

Adding a new `gravatar_enhanced_modules_whitelist` filter which is `null` by default.
When defined (as an array of strings) it will only load the specified modules.

We have also done a little refactor by adding a `Module` interface and implementing it in each of the modules.

## Testing.

Edit `gravatar-enhanced.php` with something like this:
```
diff --git a/gravatar-enhanced.php b/gravatar-enhanced.php
index 7840e58..9c98eb1 100644
--- a/gravatar-enhanced.php
+++ b/gravatar-enhanced.php
@@ -17,6 +17,9 @@ define( 'GRAVATAR_ENHANCED_VERSION', '0.9.0' );
 if ( version_compare( phpversion(), '7.4' ) >= 0 ) {
        require_once __DIR__ . '/classes/class-plugin.php';

+       // TODO REMOVE
+       add_filter( 'gravatar_enhanced_modules_whitelist', fn() => [ 'hovercards', 'avatar', 'quick_editor', 'block', 'patterns', 'oembed' ] );
+
        $gravatar_enhanced = new Automattic\Gravatar\GravatarEnhanced\Plugin();
        $gravatar_enhanced->init();
```

Play around with different values (from the ones available in `class-plugin.php`.