### PR TITLE
Exclude SCSS files from the release folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+## Description
+
+## Testing instructions

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"start": "wp-scripts start",
 		"build": "wp-scripts build && ./dev/lintfix.sh",
-		"release": "yarn build && rm -rf release && mkdir -p release && cp -R build classes *.php readme.txt changelog.txt release",
+		"release": "yarn build && rm -rf release && mkdir -p release && cp -R build *.php readme.txt changelog.txt release && mkdir release/classes && tar -C classes --exclude='*.scss' -cf - . | tar -C release/classes -xf -",
 		"dist": "yarn release && rm -rf dist && mkdir dist && mv release gravatar-enhanced && zip gravatar-enhanced.zip -r gravatar-enhanced && mv gravatar-enhanced release && mv gravatar-enhanced.zip dist",
 		"dist:github": "yarn dist && release-it",
 		"dist:svn": "yarn dist && ./dev/svn.sh $npm_package_version",

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,9 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 
 == Changelog ==
 
+= 0.10.0 =
+* Remove SCSS files from the release folder
+
 = 0.9.0 =
 * Add more Gravatar patterns
 * Pass comment initials when using initials avatar


### PR DESCRIPTION
## Description

- Exclude `*.scss` from the release > classes folder
- (Extra) Add GitHub PR template

## Test Instructions

- Check out this PR
- Run `yarn release`, and check the release > classes > patterns folder. No SCSS files in the folder