### PR TITLE
Disable comments when using Jetpack

### DIFF
--- a/classes/comments/class-comments-preferences.php
+++ b/classes/comments/class-comments-preferences.php
@@ -36,7 +36,7 @@ class Preferences {
 	 */
 	private function get_default_options() {
 		return [
-			'enabled' => false,
+			'enabled' => true,
 		];
 	}
 

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -26,8 +26,17 @@ class Comments implements Module {
 	 * @return void
 	 */
 	public function init() {
-		// Are we enabled?
-		if ( ! $this->options->enabled ) {
+		add_action( 'init', [ $this, 'maybe_load' ] );
+	}
+
+	/**
+	 * Load the module if it's not disabled.
+	 *
+	 * @return void
+	 */
+	public function maybe_load() {
+		// Bail if the module is disabled.
+		if ( ! $this->is_module_enabled() ) {
 			return;
 		}
 
@@ -40,6 +49,20 @@ class Comments implements Module {
 	 * @return void
 	 */
 	public function uninstall() {
+	}
+
+	/**
+	 * Check if the module is disabled, by either a filter or a detected incompatibility.
+	 *
+	 * @return bool
+	 */
+	private function is_module_enabled() {
+		// Check if Jetpack is active and has the comments module enabled.
+		if ( class_exists( '\Jetpack' ) && \Jetpack::is_module_active( 'comments' ) ) {
+			return false; // Disabled due to Jetpack comments module.
+		}
+
+		return $this->options->enabled;
 	}
 
 	/**

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -62,6 +62,10 @@ class Comments implements Module {
 			return false; // Disabled due to Jetpack comments module.
 		}
 
+		if ( get_template() === 'twentyeleven' ) {
+			return false; // Disabled due to Twenty Eleven theme.
+		}
+
 		return $this->options->enabled;
 	}
 

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -256,7 +256,8 @@ class DiscussionsPage {
 			$disabled = true;
 		}
 
-		if ( get_template() === 'twentyfifteen' ) {
+		// It doesn't work on this theme
+		if ( get_template() === 'twentyeleven' ) {
 			$disabled = true;
 		}
 

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -250,12 +250,32 @@ class DiscussionsPage {
 	public function display_comment_settings() {
 		$preferences = new Comments\Preferences( $this->auto_options );
 		$comments = $preferences->get_options();
+
+		$disabled = false;
+		if ( class_exists( '\Jetpack' ) && \Jetpack::is_module_active( 'comments' ) ) {
+			$disabled = true;
+		}
+
+		if ( get_template() === 'twentyfifteen' ) {
+			$disabled = true;
+		}
+
 		?>
 		<fieldset>
 			<label for="gravatar_comments">
-				<input type="checkbox" id="gravatar_comments" name="gravatar_comments" <?php checked( $comments->enabled ); ?> />
+				<input
+					type="checkbox"
+					id="gravatar_comments"
+					name="gravatar_comments"
+					<?php checked( $disabled ? false : $comments->enabled ); ?>
+					<?php echo $disabled ? 'disabled' : ''; ?>
+				/>
 
-				<?php esc_html_e( 'Show Gravatar in the comment form.', 'gravatar-enhanced' ); ?>
+				<?php if ( $disabled ) : ?>
+					<?php esc_html_e( 'Show Gravatar in the comment form (disabled due to Jetpack comments being used, or an incompatible theme).', 'gravatar-enhanced' ); ?>
+				<?php else : ?>
+					<?php esc_html_e( 'Show Gravatar in the comment form.', 'gravatar-enhanced' ); ?>
+				<?php endif; ?>
 			</label>
 		</fieldset>
 		<?php

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, batmoo, johnny5, aaronfc, wellyshen
 Tags: avatar, profile, privacy, comments, profile picture
 Tested up to: 6.7
-Stable tag: 0.9.0
+Stable tag: 0.10.0
 License: GPLv2
 
 The official Gravatar plugin, featuring privacy-focused settings, easy profile updates, and customizable Gravatar Profile blocks.
@@ -11,13 +11,14 @@ The official Gravatar plugin, featuring privacy-focused settings, easy profile u
 
 Elevate your WordPress site with Gravatar Enhanced - the plugin that simplifies digital identity and improves user engagement.
 
-Six Ways Gravatar Enhanced Improves WordPress:
+Seven Ways Gravatar Enhanced Improves WordPress:
 
 ✓ Privacy Protection - Automatic referrer blocking and optional IP address proxy
 ✓ Accessibility Improvements - Alt-text for all avatars to support screen readers
 ✓ One-Click Profile Updates - Edit Gravatar directly from the WordPress dashboard
 ✓ Versatile Profile Block & Patterns - Showcase authors and team members anywhere
 ✓ Comment Engagement Tools - Remind users to create avatars for better discussions
+✓ Comment Form Integration - Show Gravatar directly in the comment form
 ✓ WooCommerce Integration - Personalized account pages for customers
 
 === Privacy Protection ===
@@ -34,6 +35,9 @@ Enhance your website with our custom Gravatar profile block and patterns. Seamle
 
 === Comment Engagement Tools ===
 Automatically remind commenters without avatars to create a Gravatar, increasing visual engagement on your blog.
+
+=== Comment Form Integration ===
+When the plugin is enabled we will show a Gravatar profile directly in the comment form, and allow the profile to be updated, so users can feel confident their details are correct, and the site shows richer comments.
 
 === WooCommerce Integration ===
 Enhance your WooCommerce store by displaying user Gravatar avatars on the My Account page. Customers can view and update their avatars directly from their account dashboard, improving personalization and user engagement.
@@ -88,6 +92,7 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 == Changelog ==
 
 = 0.10.0 =
+* Add Gravatar Quick Editor to comment form
 * Remove SCSS files from the release folder
 
 = 0.9.0 =


### PR DESCRIPTION
Disable the commenting feature when Jetpack comments, or the theme Twenty Eleven, is used.

The module itself is disabled. The option on the discussions page is visible, but disabled with a reason.

This also enables the commenting module by default and updates the readme to mention it.

## Testing instructions

- Activate Twenty Eleven
- Visit the discussions page and confirm the comments module is disabled and the checkbox is inactive
- If you have Jetpack then you can also test with the Jetpack Discussions > Comment form option, but it doesn't run locally so is a bit more difficult to test. The code is the same as used for hovercards so it's fairly safe to just code review it.