### PR TITLE
Add a Gravatar invitation link to the Profile block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,9 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 
 == Changelog ==
 
+= 0.11.0 =
+* Add a Gravatar invitation link to the Profile block
+
 = 0.10.0 =
 * Add Gravatar Quick Editor to comment form
 * Remove SCSS files from the release folder

--- a/src/block/block.json
+++ b/src/block/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Gravatar Profile",
 	"description": "Display user information directly from Gravatar Public Profiles.",
 	"category": "widgets",

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -147,8 +147,8 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 	// Fetch the profile data when the email changes.
 	useEffect( () => {
 		setApiStatus( undefined );
-		setErrorMsg( '' );
 		setErrorCode( undefined );
+		setErrorMsg( '' );
 
 		const trimmedEmail = userEmail.trim();
 

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -11,7 +11,8 @@ import clsx from 'clsx';
 import type { MainEditAttrs } from './shared-types';
 import { Layout, UserTypes } from './shared-types';
 import { getDefaultTemplate, getPortraitTemplate } from './editor-templates';
-import { fetchProfile as basedFetchProfile, getExistingBlocks, validateEmail, getAvatarUrlWithSize } from './utils';
+import { fetchProfile as basedFetchProfile, getExistingBlocks, getAvatarUrlWithSize } from './utils';
+import isEmail from '../shared/is-email';
 
 import './shared.scss';
 import './edit.scss';
@@ -35,6 +36,7 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 	const [ emailInputVal, setEmailInputVal ] = useState( userEmail );
 	const [ apiStatus, setApiStatus ] = useState< ApiStatus >();
 	const [ errorMsg, setErrorMsg ] = useState( '' );
+	const [ errorCode, setErrorCode ] = useState< number >();
 	const prevExistingBlocksRef = useRef< string[] >( null );
 	const deletedElementsRef = useRef( deletedElements ); // Avoid unnecessary `useEffect` calls.
 	deletedElementsRef.current = deletedElements;
@@ -146,6 +148,7 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 	useEffect( () => {
 		setApiStatus( undefined );
 		setErrorMsg( '' );
+		setErrorCode( undefined );
 
 		const trimmedEmail = userEmail.trim();
 
@@ -156,18 +159,19 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 		const fetchProfile = async ( email: string ) => {
 			setApiStatus( 'loading' );
 
-			if ( ! validateEmail( email ) ) {
+			if ( ! isEmail( email ) ) {
 				setApiStatus( 'error' );
 				setErrorMsg( __( 'Please enter a valid email.', 'gravatar-enhanced' ) );
 				return;
 			}
 
 			const hashedEmail = sha256( email.toLowerCase() );
-			const { error, data } = await basedFetchProfile( hashedEmail );
+			const { errorCode: errCode, errorMsg: errMsg, data } = await basedFetchProfile( hashedEmail );
 
-			if ( error ) {
+			if ( errCode ) {
 				setApiStatus( 'error' );
-				setErrorMsg( error );
+				setErrorCode( errCode );
+				setErrorMsg( errMsg );
 			} else {
 				setApiStatus( 'success' );
 
@@ -231,15 +235,35 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 						/>
 					) }
 					{ userType === UserTypes.EMAIL && (
-						<TextControl
-							type="email"
-							value={ emailInputVal }
-							onChange={ ( email ) => {
-								setEmailInputVal( email );
-								debouncedSetUserEmail( email );
-							} }
-							placeholder={ __( 'Enter email', 'gravatar-enhanced' ) }
-						/>
+						<>
+							<TextControl
+								type="email"
+								value={ emailInputVal }
+								onChange={ ( email ) => {
+									setEmailInputVal( email );
+									debouncedSetUserEmail( email );
+								} }
+								placeholder={ __( 'Enter email', 'gravatar-enhanced' ) }
+							/>
+							{ errorCode === 404 && (
+								<a
+									href={
+										`mailto:${ emailInputVal }` +
+										`?subject=${ encodeURIComponent( 'Let’s set up your Gravatar profile' ) }` +
+										`&body=${ encodeURIComponent(
+											`Hi there,\n\n` +
+												`I use Gravatar to create and manage a unified online profile — it’s free, fast to set up, and keeps your presence consistent wherever you interact online.\n\n` +
+												`Set up your Gravatar profile now: https://gravatar.com\n\n\n` +
+												`Cheers,`
+										) }`
+									}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __( 'Invite to join Gravatar', 'gravatar-enhanced' ) }
+								</a>
+							) }
+						</>
 					) }
 				</PanelBody>
 			</InspectorControls>

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -4,7 +4,7 @@ import { InspectorControls, InnerBlocks, useBlockProps } from '@wordpress/block-
 import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import _debounce from 'lodash.debounce';
 import { sha256 } from 'js-sha256';
 import clsx from 'clsx';
@@ -249,12 +249,18 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 								<a
 									href={
 										`mailto:${ emailInputVal }` +
-										`?subject=${ encodeURIComponent( 'Let’s set up your Gravatar profile' ) }` +
+										`?subject=${ encodeURIComponent(
+											__( 'Let’s set up your Gravatar profile', 'gravatar-enhanced' )
+										) }` +
 										`&body=${ encodeURIComponent(
-											`Hi there,\n\n` +
-												`I use Gravatar to create and manage a unified online profile — it’s free, fast to set up, and keeps your presence consistent wherever you interact online.\n\n` +
-												`Set up your Gravatar profile now: https://gravatar.com\n\n\n` +
-												`Cheers,`
+											sprintf(
+												// translators: %1$s = newline
+												__(
+													'Hi there,%1$s%1$sI use Gravatar to create and manage a unified online profile — it’s free, fast to set up, and keeps your presence consistent wherever you interact online.%1$s%1$sSet up your Gravatar profile now: https://gravatar.com%1$s%1$sCheers,',
+													'gravatar-enhanced'
+												),
+												'\n'
+											)
 										) }`
 									}
 									target="_blank"

--- a/src/block/editor-blocks/group/block.json
+++ b/src/block/editor-blocks/group/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block-group",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Group",
 	"description": "The Group block for the Gravatar block.",
 	"category": "layout",

--- a/src/block/editor-blocks/image/block.json
+++ b/src/block/editor-blocks/image/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block-image",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Image",
 	"description": "The Image block for the Gravatar block.",
 	"category": "layout",

--- a/src/block/editor-blocks/link/block.json
+++ b/src/block/editor-blocks/link/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block-link",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Link",
 	"description": "The Link block for the Gravatar block.",
 	"category": "layout",

--- a/src/block/editor-blocks/name/block.json
+++ b/src/block/editor-blocks/name/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block-name",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Name",
 	"description": "The Name block for the Gravatar block.",
 	"category": "layout",

--- a/src/block/editor-blocks/paragraph/block.json
+++ b/src/block/editor-blocks/paragraph/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "gravatar/block-paragraph",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"title": "Paragraph",
 	"description": "The Paragraph block for the Gravatar block.",
 	"category": "layout",

--- a/src/block/utils/fetch-profile.ts
+++ b/src/block/utils/fetch-profile.ts
@@ -2,8 +2,8 @@ import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
 interface Response {
-	errorCode?: number;
 	data?: GravatarAPIProfile;
+	errorCode?: number;
 	errorMsg?: string;
 }
 

--- a/src/block/utils/fetch-profile.ts
+++ b/src/block/utils/fetch-profile.ts
@@ -2,8 +2,9 @@ import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
 interface Response {
+	errorCode?: number;
 	data?: GravatarAPIProfile;
-	error?: string;
+	errorMsg?: string;
 }
 
 const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
@@ -37,6 +38,6 @@ export default async function fetchProfile( hashedEmail: string ): Promise< Resp
 				break;
 		}
 
-		return { error: message };
+		return { errorCode: code, errorMsg: message };
 	}
 }

--- a/src/block/utils/index.ts
+++ b/src/block/utils/index.ts
@@ -1,6 +1,5 @@
 export { default as fetchProfile } from './fetch-profile';
 export { default as getExistingBlocks } from './get-existing-blocks';
-export { default as validateEmail } from './validate-email';
 export { default as getBlockTemplate } from './get-block-template';
 export { default as getViewElement } from './get-view-element';
 export { default as getAvatarUrlWithSize } from './get-avatar-url-with-size';

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -3,16 +3,12 @@ import { GravatarQuickEditorCore } from '@gravatar-com/quick-editor';
 import { Hovercards } from '@gravatar-com/hovercards';
 import trackEvent from '../shared/analytics';
 import updateAvatars from '../shared/update-avatars';
+import isEmail from '../shared/is-email';
 import { adjustGravatarPosition, fetchUserProfile, suggestProfile, hideProfile, showProfile } from './profile';
 import { GRAVATAR_CONTAINER, COMMENT_EMAIL_WRAPPER, COMMENT_EMAIL_FIELD } from './constants';
 import './style.scss';
 
 const INPUT_TIMEOUT = 1000;
-
-function isEmail( email: string ) {
-	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-	return emailRegex.test( email );
-}
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	const email = document.querySelector( COMMENT_EMAIL_FIELD ) as HTMLInputElement;

--- a/src/shared/is-email.ts
+++ b/src/shared/is-email.ts
@@ -1,3 +1,3 @@
-export default function validateEmail( email: string ): boolean {
+export default function isEmail( email: string ): boolean {
 	return /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test( email );
 }


### PR DESCRIPTION
## Description

- Implement Gravatar invitation link for the profile block (#56)
- (Extra) Reuse the `isEmail` function

## Testing instructions

- Install [this plugin](https://github.com/Automattic/gravatar-enhanced?tab=readme-ov-file#development)
- Check out this PR
- Add the profile block
- Go to the settings of the block, and change the "SELECT USER" to email
- Try to enter a non-Gravatar profile email, and then you will see the invitation link:

<img width="1089" alt="截圖 2025-03-27 下午5 42 21" src="https://github.com/user-attachments/assets/40c48945-9bcb-4706-b545-4897f9fdf1a2" />

- Click the link, and you will see this default email template:

<img width="838" alt="截圖 2025-03-27 下午6 05 21" src="https://github.com/user-attachments/assets/8979d01e-6a07-47b3-8bbc-bfe36aebc78e" />

- Use incognito mode, go to a blog post, and enter an invalid email address, the email validation should work the same

