### PR TITLE
Fix profile block for templates.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ A: It sends a single, polite email to commenters without Gravatars, inviting the
 
 = 0.11.0 =
 * Add a Gravatar invitation link to the Profile block
+* Fix support for Author in templates for Profile block.
 
 = 0.10.0 =
 * Add Gravatar Quick Editor to comment form

--- a/src/block/block.json
+++ b/src/block/block.json
@@ -43,6 +43,7 @@
 			"default": {}
 		}
 	},
+	"usesContext": [ "postType", "postId" ],
 	"supports": {
 		"html": false,
 		"color": {

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -1,9 +1,9 @@
 import type { BlockEditProps } from '@wordpress/blocks';
 import { createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
-import { InspectorControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import _debounce from 'lodash.debounce';
 import { sha256 } from 'js-sha256';
@@ -11,7 +11,7 @@ import clsx from 'clsx';
 import type { MainEditAttrs } from './shared-types';
 import { Layout, UserTypes } from './shared-types';
 import { getDefaultTemplate, getPortraitTemplate } from './editor-templates';
-import { fetchProfile as basedFetchProfile, getExistingBlocks, getAvatarUrlWithSize } from './utils';
+import { fetchProfile as basedFetchProfile, getAvatarUrlWithSize, getExistingBlocks } from './utils';
 import isEmail from '../shared/is-email';
 
 import './shared.scss';
@@ -59,6 +59,17 @@ export default function Edit( { context: { postType, postId }, attributes, setAt
 	}
 
 	const blockProps = useBlockProps();
+
+	// Get author email from postType and postId in the context.
+	const authorEmail = useSelect(
+		( select: SelectFn ) => {
+			const { getEditedEntityRecord, getEntityRecord } = select( 'core' );
+			const _authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
+
+			return _authorId ? getEntityRecord( 'root', 'user', _authorId )?.email : '';
+		},
+		[ postType, postId ]
+	);
 
 	const userTypeOptions = [
 		{ label: __( 'Author', 'gravatar-enhanced' ), value: UserTypes.AUTHOR },
@@ -126,7 +137,8 @@ export default function Edit( { context: { postType, postId }, attributes, setAt
 		setErrorCode( undefined );
 		setErrorMsg( '' );
 
-		const trimmedEmail = userEmail.trim();
+		// For Author we use authorEmail, for other cases we use userEmail.
+		const trimmedEmail = userType === UserTypes.AUTHOR && authorEmail ? authorEmail.trim() : userEmail.trim();
 
 		if ( ! trimmedEmail ) {
 			return;
@@ -161,7 +173,7 @@ export default function Edit( { context: { postType, postId }, attributes, setAt
 		};
 
 		fetchProfile( trimmedEmail );
-	}, [ avatarUrlSizeParam, clientId, defaultAvatarSize, replaceInnerBlocks, userEmail ] );
+	}, [ avatarUrlSizeParam, clientId, defaultAvatarSize, replaceInnerBlocks, userEmail, authorEmail, userType ] );
 
 	// Reset the block items from the navigation menu when the API status changes.
 	useEffect( () => {

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -21,7 +21,7 @@ type ApiStatus = 'loading' | 'error' | 'success';
 
 type Props = BlockEditProps< MainEditAttrs >;
 
-export default function Edit( { attributes, setAttributes, clientId }: Props ) {
+export default function Edit( { context: { postType, postId }, attributes, setAttributes, clientId }: Props ) {
 	const {
 		layout,
 		avatarUrlSizeParam,
@@ -60,16 +60,8 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 
 	const blockProps = useBlockProps();
 
-	const authorEmail = useSelect( ( select: SelectFn ) => {
-		const postType = select( 'core/editor' ).getCurrentPostType();
-		const postId = select( 'core/editor' ).getCurrentPostId();
-		const authorId = select( 'core' ).getEntityRecord( 'postType', postType, postId )?.author;
-
-		return select( 'core' ).getEntityRecord( 'root', 'user', authorId )?.email || '';
-	}, [] );
-
 	const userTypeOptions = [
-		...( authorEmail ? [ { label: __( 'Author', 'gravatar-enhanced' ), value: UserTypes.AUTHOR } ] : [] ),
+		{ label: __( 'Author', 'gravatar-enhanced' ), value: UserTypes.AUTHOR },
 		{ label: __( 'User', 'gravatar-enhanced' ), value: UserTypes.USER },
 		{ label: __( 'Custom email', 'gravatar-enhanced' ), value: UserTypes.EMAIL },
 	];
@@ -99,22 +91,6 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 			setAttributes( { userEmail: firstUserEmail } );
 		}
 	}, [ firstUserEmail, setAttributes, userEmail, userType, users ] );
-
-	const isEditingTemplate = useSelect( ( select: SelectFn ) => select( 'core/edit-site' )?.isPage() === false, [] );
-
-	// When the block is created, set the `userType` and `userEmail` based on the available data.
-	useEffect( () => {
-		if ( userType === UserTypes.EMAIL || userEmail ) {
-			return;
-		}
-
-		// When first time to edit a template, the `authorEmail` is not available. Use the first user's email as a fallback.
-		if ( isEditingTemplate && userType === UserTypes.AUTHOR ) {
-			setAttributes( { userType: UserTypes.USER, userEmail: firstUserEmail } );
-		} else {
-			setAttributes( { userEmail: authorEmail } );
-		}
-	}, [ authorEmail, firstUserEmail, isEditingTemplate, setAttributes, userEmail, userType ] );
 
 	// Set the deleted elements when the inner blocks change.
 	useSelect(
@@ -200,9 +176,6 @@ export default function Edit( { attributes, setAttributes, clientId }: Props ) {
 	function handleUserTypeChange( type: UserTypes ) {
 		let email = '';
 
-		if ( type === UserTypes.AUTHOR ) {
-			email = authorEmail;
-		}
 		if ( type === UserTypes.USER ) {
 			email = firstUserEmail;
 		}

--- a/src/block/edit.tsx
+++ b/src/block/edit.tsx
@@ -64,9 +64,9 @@ export default function Edit( { context: { postType, postId }, attributes, setAt
 	const authorEmail = useSelect(
 		( select: SelectFn ) => {
 			const { getEditedEntityRecord, getEntityRecord } = select( 'core' );
-			const _authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
+			const authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
 
-			return _authorId ? getEntityRecord( 'root', 'user', _authorId )?.email : '';
+			return authorId ? getEntityRecord( 'root', 'user', authorId )?.email : '';
 		},
 		[ postType, postId ]
 	);

--- a/src/block/render.php
+++ b/src/block/render.php
@@ -18,7 +18,26 @@
  * } $attributes
  */
 
-$email = strtolower( trim( $attributes['userEmail'] ) );
+/**
+ * @var WP_Block $block
+ */
+
+$email = $attributes['userEmail'] ?? '';
+
+// For the author type, get the email from the author of the post in the context.
+if ($attributes['userType'] === 'author') {
+	$postId = $block->context['postId'] ?? null;
+	if ( $postId ) {
+		$authorId = get_post_field( 'post_author', $postId );
+		if ( $authorId ) {
+			// We are overriding any email that was passed in the attributes
+			$email = get_the_author_meta( 'user_email', (int) $authorId );
+		}
+	}
+}
+
+// Normalize and sanitize email.
+$email = strtolower( trim( $email ) );
 $email = sanitize_email( $email );
 
 // If the `userType` is email, but the email isn't valid, don't render the block.


### PR DESCRIPTION
Fixes #85 

## Description
- Reworked the way we calculate the author email by using context's `postId` and `postType`.

## Testing instructions
- [ ] Check code.
- Checkout to branch.
- Add a Profile Block in a post and test:
  - [ ] Author option works as expected (post's author).
  - [ ] User option works as expected (selected user).
  - [ ] Custom email option works as expected.
  - [ ] Confirm each of the above are correctly displayed in the post view (not the editor).
- [ ] Repeat above tests with a Page.
- Go to site editor and edit the "Single Post" or "Page" templates.
- [ ] Confirm Author option works as expected in the editor.
- [ ] Confirm option works as expected in the final view.

## Screenshots

### Editor view

![image](https://github.com/user-attachments/assets/8705e069-b024-4061-b1a4-5aac50cbcd00)

![image](https://github.com/user-attachments/assets/17b91ac0-17a2-49c6-ad8e-f8c62ecca5bf)

![image](https://github.com/user-attachments/assets/4442768b-d900-4ba0-b88b-83e5c2d165f7)

![image](https://github.com/user-attachments/assets/2c584c95-ccf7-4d5b-a48b-60552f8fc4f2)

![image](https://github.com/user-attachments/assets/9e4fcd98-6da4-4f8f-895c-dbfc97f4aea2)

### Post public view

![gravatar-enhanced local_8-2_](https://github.com/user-attachments/assets/30de1f1d-3219-4f12-b201-13a0afd5a7b6)

### Author in Single Post template

![image](https://github.com/user-attachments/assets/9a8ca72b-b7eb-4126-a496-10c507311a61)
