### PR TITLE
Add support for core's SHA-256 handling

### DIFF
--- a/classes/avatar/class-avatar-id.php
+++ b/classes/avatar/class-avatar-id.php
@@ -48,8 +48,8 @@ class AvatarId {
 		if ( is_numeric( $id_or_email ) ) {
 			$user = get_user_by( 'id', absint( $id_or_email ) );
 		} elseif ( is_string( $id_or_email ) ) {
-			if ( str_contains( $id_or_email, '@md5.gravatar.com' ) ) {
-				// MD5 hash.
+			if ( str_contains( $id_or_email, '@md5.gravatar.com' ) || str_contains( $id_or_email, '@sha256.gravatar.com' ) ) {
+				// MD5 or SHA256 hash.
 				list( $email_hash ) = explode( '@', $id_or_email );
 			} else {
 				// Email address.


### PR DESCRIPTION
Fixes #95 

## Description
- In 6.8, WP core added support for SHA-256 hashes with Gravatar images. In [their implementation](https://github.com/WordPress/WordPress/commit/d4272280241e51259b065428d6be62e3f66a5f5f), they added a new `@sha256.gravatar.com` special email to indicate when the passed identifier is actually just a SHA-256 hash. 
- This adds support for that special hash. You can see it being used on `/wp-admin/credits.php`. 

## Testing instructions
- Visit `/wp-admin/credits.php` and ensure the avatars show up correctly. 
