### PR TITLE
Add author archive module

### DIFF
--- a/classes/analytics/class-analytics-options.php
+++ b/classes/analytics/class-analytics-options.php
@@ -3,7 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Analytics;
 
 /**
- * @psalm-type AnalyticsOptionsArray = array{
+ * @phpstan-type AnalyticsOptionsArray = array{
  *   enabled: bool,
  * }
  */

--- a/classes/analytics/class-analytics-preferences.php
+++ b/classes/analytics/class-analytics-preferences.php
@@ -5,8 +5,8 @@ namespace Automattic\Gravatar\GravatarEnhanced\Analytics;
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type AnalyticsOptionsArray from Options
- * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
+ * @phpstan-import-type AnalyticsOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
 	const OPTION_NAME = 'analytics';

--- a/classes/author-archive/class-author-archive-options.php
+++ b/classes/author-archive/class-author-archive-options.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\AuthorArchive;
+
+/**
+ * @phpstan-type AuthorArchiveAutoShow 'off'|'top'|'bottom'
+ * @phpstan-type AuthorArchiveOptionsArray array{
+ *   auto_show: AuthorArchiveAutoShow,
+ * }
+ */
+class Options {
+	const AUTO_SHOW_OFF = 'off';
+	const AUTO_SHOW_TOP = 'top';
+	const AUTO_SHOW_BOTTOM = 'bottom';
+
+	/** @var AuthorArchiveAutoShow */
+	public $auto_show;
+
+	/**
+	 * @param AuthorArchiveAutoShow $auto_show
+	 */
+	public function __construct( $auto_show ) {
+		$this->auto_show = $auto_show;
+	}
+
+	/**
+	 * @return AuthorArchiveOptionsArray
+	 */
+	public function to_array() {
+		return [
+			'auto_show' => $this->auto_show,
+		];
+	}
+
+	/**
+	 * @param AuthorArchiveOptionsArray $options
+	 * @return Options
+	 */
+	public static function from_array( $options ) {
+		return new Options( $options['auto_show'] );
+	}
+}

--- a/classes/author-archive/class-author-archive-preferences.php
+++ b/classes/author-archive/class-author-archive-preferences.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\AuthorArchive;
+
+use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
+
+/**
+ * @phpstan-import-type AuthorArchiveOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
+ */
+class Preferences {
+	const OPTION_NAME = 'author_archive';
+
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @param CoreOptions\SavedOptions $saved_options
+	 * @param Options | null $new_options
+	 */
+	public function __construct( $saved_options, $new_options = null ) {
+		/** @var AuthorArchiveOptionsArray */
+		$options = array_merge(
+			$this->get_default_options(),
+			$saved_options->get_group( self::OPTION_NAME ),
+			$new_options ? $new_options->to_array() : []
+		);
+
+		$this->options = Options::from_array( $options );
+	}
+
+	/**
+	 * @return AuthorArchiveOptionsArray
+	 */
+	private function get_default_options() {
+		return [
+			'auto_show' => Options::AUTO_SHOW_OFF,
+		];
+	}
+
+	/**
+	 * @return Options
+	 */
+	public function get_options() {
+		return $this->options;
+	}
+
+	/**
+	 * @return array<string,AuthorArchiveOptionsArray>
+	 */
+	public function get_as_preferences() {
+		return [
+			self::OPTION_NAME => $this->options->to_array(),
+		];
+	}
+}

--- a/classes/author-archive/class-author-archive.php
+++ b/classes/author-archive/class-author-archive.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\AuthorArchive;
+
+use Automattic\Gravatar\GravatarEnhanced\Module;
+use WP_Block;
+
+require_once __DIR__ . '/class-author-archive-options.php';
+require_once __DIR__ . '/class-author-archive-preferences.php';
+
+class AuthorArchive implements Module {
+	/**
+	 * @var Options
+	 */
+	private $options;
+
+	/**
+	 * @param Preferences $preferences
+	 */
+	public function __construct( $preferences ) {
+		$this->options = $preferences->get_options();
+	}
+
+
+	/**
+	 * @return void
+	 */
+	public function init() {
+		if ( $this->options->auto_show === Options::AUTO_SHOW_OFF ) {
+			return;
+		}
+
+		add_filter( 'render_block_core/query', [ $this, 'render_block_core_query' ], 10, 2 );
+	}
+
+	/**
+	 * Render block core query.
+	 *
+	 * @param string $block_content The block content.
+	 * @param WP_Block $block The block.
+	 * @return string
+	 */
+	public function render_block_core_query( $block_content, $block ) {
+		if ( ! is_author() ) {
+			return $block_content;
+		}
+
+		// Add card to end of content
+		$blocks = parse_blocks( '<!-- wp:gravatar/block /-->' );
+		$card = render_block( $blocks[0] );
+
+		if ( $this->options->auto_show === Options::AUTO_SHOW_TOP ) {
+			$block_content = $card . $block_content;
+		} elseif ( $this->options->auto_show === Options::AUTO_SHOW_BOTTOM ) {
+			$block_content .= $card;
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function uninstall() {}
+}

--- a/classes/avatar/class-avatar-options.php
+++ b/classes/avatar/class-avatar-options.php
@@ -3,7 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Avatar;
 
 /**
- * @psalm-type AvatarOptionsArray = array{
+ * @phpstan-type AvatarOptionsArray = array{
  *   force_default_avatar: bool,
  *   force_alt: bool,
  * }

--- a/classes/avatar/class-avatar-preferences.php
+++ b/classes/avatar/class-avatar-preferences.php
@@ -5,8 +5,8 @@ namespace Automattic\Gravatar\GravatarEnhanced\Avatar;
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type AvatarOptionsArray from Options
- * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
+ * @phpstan-import-type AvatarOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
 	const OPTION_NAME = 'avatar';

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/woocommerce/class-admin-customers.php';
 require_once __DIR__ . '/woocommerce/class-my-account.php';
 require_once __DIR__ . '/oembed/class-oembed.php';
 require_once __DIR__ . '/comments/class-comments.php';
+require_once __DIR__ . '/author-archive/class-author-archive.php';
 
 class Plugin {
 	const OPTION_NAME_AUTO = 'gravatar_enhanced_options';
@@ -97,6 +98,11 @@ class Plugin {
 	private $comments;
 
 	/**
+	 * @var AuthorArchive\AuthorArchive
+	 */
+	private $author_archive;
+
+	/**
 	 * @var Module[]
 	 */
 	private $modules;
@@ -122,6 +128,7 @@ class Plugin {
 		$this->wc_my_account = new Woocommerce\MyAccount();
 		$this->oembed = new OEmbed\OEmbed();
 		$this->comments = new Comments\Comments( new Comments\Preferences( $this->auto_options ) );
+		$this->author_archive = new AuthorArchive\AuthorArchive( new AuthorArchive\Preferences( $this->auto_options ) );
 
 		// Collect all modules and filter them based on the whitelist if available.
 		$this->modules = [
@@ -137,7 +144,9 @@ class Plugin {
 			'wc_my_account' => $this->wc_my_account,
 			'oembed' => $this->oembed,
 			'comments' => $this->comments,
+			'author_archive' => $this->author_archive,
 		];
+
 		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null );
 		if ( is_array( $modules_whitelist ) ) {
 			$this->modules = array_intersect_key( $this->modules, array_flip( $modules_whitelist ) );

--- a/classes/comments/class-comments-options.php
+++ b/classes/comments/class-comments-options.php
@@ -3,7 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 
 /**
- * @psalm-type CommentsOptionsArray = array{
+ * @phpstan-type CommentsOptionsArray = array{
  *   enabled: bool,
  * }
  */

--- a/classes/comments/class-comments-preferences.php
+++ b/classes/comments/class-comments-preferences.php
@@ -5,8 +5,8 @@ namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type CommentsOptionsArray from Options
- * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
+ * @phpstan-import-type CommentsOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
 	const OPTION_NAME = 'comments';

--- a/classes/email/class-email-options.php
+++ b/classes/email/class-email-options.php
@@ -3,7 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Email;
 
 /**
- * @psalm-type EmailOptionsArray = array{
+ * @phpstan-type EmailOptionsArray = array{
  *   enabled: bool,
  *   message: string,
  * }

--- a/classes/email/class-email-preferences.php
+++ b/classes/email/class-email-preferences.php
@@ -5,8 +5,8 @@ namespace Automattic\Gravatar\GravatarEnhanced\Email;
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type EmailOptionsArray from Options
- * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
+ * @phpstan-import-type EmailOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
 	const OPTION_NAME = 'email';

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -8,12 +8,14 @@ use Automattic\Gravatar\GravatarEnhanced\Email;
 use Automattic\Gravatar\GravatarEnhanced\Avatar;
 use Automattic\Gravatar\GravatarEnhanced\Analytics;
 use Automattic\Gravatar\GravatarEnhanced\Comments;
+use Automattic\Gravatar\GravatarEnhanced\AuthorArchive;
 
 require_once __DIR__ . '/class-saved-options.php';
 require_once __DIR__ . '/class-migrate.php';
 
 /**
- * @psalm-import-type ProxyOptionsType from Proxy\Options
+ * @phpstan-import-type ProxyOptionsType from Proxy\Options
+ * @phpstan-import-type AuthorArchiveAutoShow from AuthorArchive\Options
  */
 class DiscussionsPage {
 	/**
@@ -105,7 +107,49 @@ class DiscussionsPage {
 				'discussion',
 				'avatars'
 			);
+		}
+
+		if ( in_array( 'author_archive', $this->enabled_modules, true ) ) {
+			add_settings_field(
+				'author-archive-options',
+				__( 'Author Archive', 'gravatar-enhanced' ),
+				[ $this, 'display_author_archive_settings' ],
+				'discussion',
+				'avatars'
+			);
+		}
 	}
+
+	/**
+	 * Callback to show author archive options
+	 *
+	 * @return void
+	 */
+	public function display_author_archive_settings() {
+		$preferences = new AuthorArchive\Preferences( $this->auto_options );
+		$author_archive = $preferences->get_options();
+
+		?>
+		<fieldset>
+			<label for="gravatar_author_archive">
+				<?php esc_html_e( 'Automatically show a Gravatar block on author archive pages. You can manually add one from the site editor.', 'gravatar-enhanced' ); ?>
+			</label>
+
+			<p>
+				<select name="gravatar_author_archive">
+					<option value="<?php echo esc_attr( AuthorArchive\Options::AUTO_SHOW_OFF ); ?>" <?php selected( AuthorArchive\Options::AUTO_SHOW_OFF, $author_archive->auto_show ); ?>>
+						<?php esc_html_e( 'Do not automatically show a Gravatar block', 'gravatar-enhanced' ); ?>
+					</option>
+					<option value="<?php echo esc_attr( AuthorArchive\Options::AUTO_SHOW_TOP ); ?>" <?php selected( AuthorArchive\Options::AUTO_SHOW_TOP, $author_archive->auto_show ); ?>>
+						<?php esc_html_e( 'Show at the top of the page', 'gravatar-enhanced' ); ?>
+					</option>
+					<option value="<?php echo esc_attr( AuthorArchive\Options::AUTO_SHOW_BOTTOM ); ?>"<?php selected( AuthorArchive\Options::AUTO_SHOW_BOTTOM, $author_archive->auto_show ); ?>>
+						<?php esc_html_e( 'Show at the bottom of the page', 'gravatar-enhanced' ); ?>
+					</option>
+				</select>
+			</p>
+		</fieldset>
+		<?php
 	}
 
 	/**
@@ -291,7 +335,7 @@ class DiscussionsPage {
 		}
 
 		// Handle auto options.
-		if ( in_array('avatar', $this->enabled_modules, true) ) {
+		if ( in_array( 'avatar', $this->enabled_modules, true ) ) {
 			$avatar_preferences = $this->get_avatar_preferences();
 			$this->auto_options->update( $avatar_preferences );
 		}
@@ -311,6 +355,11 @@ class DiscussionsPage {
 			$this->auto_options->update( $comment_preferences );
 		}
 
+		if ( in_array( 'author_archive', $this->enabled_modules, true ) ) {
+			$author_archive_preferences = $this->get_author_archive_preferences();
+			$this->auto_options->update( $author_archive_preferences );
+		}
+
 		$this->auto_options->save();
 
 		// Handle lazy options.
@@ -318,7 +367,28 @@ class DiscussionsPage {
 			$email_preferences = $this->get_email_preferences();
 			$this->lazy_options->update( $email_preferences );
 		}
+
 		$this->lazy_options->save();
+	}
+
+	/**
+	 * @return AuthorArchive\Preferences
+	 */
+	private function get_author_archive_preferences() {
+		/** @var AuthorArchiveAutoShow */
+		$auto_show = AuthorArchive\Options::AUTO_SHOW_OFF;
+		if ( in_array( $_POST['gravatar_author_archive'], [ AuthorArchive\Options::AUTO_SHOW_OFF, AuthorArchive\Options::AUTO_SHOW_TOP, AuthorArchive\Options::AUTO_SHOW_BOTTOM ], true ) ) {
+			/** @var AuthorArchiveAutoShow */
+			$auto_show = sanitize_text_field( $_POST['gravatar_author_archive'] );
+		}
+
+		$options = [
+			'auto_show' => $auto_show,
+		];
+
+		$new_options = AuthorArchive\Options::from_array( $options );
+
+		return new AuthorArchive\Preferences( $this->auto_options, $new_options );
 	}
 
 	/**

--- a/classes/options/class-saved-options.php
+++ b/classes/options/class-saved-options.php
@@ -7,22 +7,25 @@ use Automattic\Gravatar\GravatarEnhanced\Proxy;
 use Automattic\Gravatar\GravatarEnhanced\Analytics;
 use Automattic\Gravatar\GravatarEnhanced\Email;
 use Automattic\Gravatar\GravatarEnhanced\Comments;
+use Automattic\Gravatar\GravatarEnhanced\AuthorArchive;
 
 /**
- * @psalm-import-type AvatarOptionsArray from Avatar\Options
- * @psalm-import-type ProxyOptionsArray from Proxy\Options
- * @psalm-import-type AnalyticsOptionsArray from Analytics\Options
- * @psalm-import-type EmailOptionsArray from Email\Options
- * @psalm-import-type CommentsOptionsArray from Comments\Options
- * @psalm-type Preferences Comments\Preferences | Avatar\Preferences | Proxy\Preferences | Email\Preferences | Analytics\Preferences
+ * @phpstan-import-type AvatarOptionsArray from Avatar\Options
+ * @phpstan-import-type ProxyOptionsArray from Proxy\Options
+ * @phpstan-import-type AnalyticsOptionsArray from Analytics\Options
+ * @phpstan-import-type EmailOptionsArray from Email\Options
+ * @phpstan-import-type CommentsOptionsArray from Comments\Options
+ * @phpstan-import-type AuthorArchiveOptionsArray from AuthorArchive\Options
+ * @phpstan-type Preferences Comments\Preferences | Avatar\Preferences | Proxy\Preferences | Email\Preferences | Analytics\Preferences | AuthorArchive\Preferences
  *
- * @psalm-type OptionsArray = array{
+ * @phpstan-type OptionsArray = array{
  *   avatar?: AvatarOptionsArray,
  *   proxy?: ProxyOptionsArray,
  *   analytics?: AnalyticsOptionsArray,
  *   email?: EmailOptionsArray,
  *   version?: string,
  *   comments?: CommentsOptionsArray,
+ *   author_archive?: AuthorArchiveOptionsArray,
  * }
  */
 class SavedOptions {
@@ -67,7 +70,7 @@ class SavedOptions {
 
 	/**
 	 * @param string $group
-	 * @return AvatarOptionsArray | ProxyOptionsArray | AnalyticsOptionsArray | EmailOptionsArray | array{}
+	 * @return AvatarOptionsArray | ProxyOptionsArray | AnalyticsOptionsArray | EmailOptionsArray | AuthorArchiveOptionsArray | array{}
 	 */
 	public function get_group( $group ) {
 		if ( isset( $this->options[ $group ] ) && is_array( $this->options[ $group ] ) ) {

--- a/classes/proxy/class-proxy-options.php
+++ b/classes/proxy/class-proxy-options.php
@@ -3,8 +3,8 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Proxy;
 
 /**
- * @psalm-type ProxyOptionsType = 'disabled' | 'local' | 'private'
- * @psalm-type ProxyOptionsArray = array{
+ * @phpstan-type ProxyOptionsType = 'disabled' | 'local' | 'private'
+ * @phpstan-type ProxyOptionsArray = array{
  *   type: ProxyOptionsType,
  *   time?: int,
  * }

--- a/classes/proxy/class-proxy-preferences.php
+++ b/classes/proxy/class-proxy-preferences.php
@@ -5,8 +5,8 @@ namespace Automattic\Gravatar\GravatarEnhanced\Proxy;
 use Automattic\Gravatar\GravatarEnhanced\Options as CoreOptions;
 
 /**
- * @psalm-import-type ProxyOptionsArray from Options
- * @psalm-import-type OptionsArray from CoreOptions\SavedOptions
+ * @phpstan-import-type ProxyOptionsArray from Options
+ * @phpstan-import-type OptionsArray from CoreOptions\SavedOptions
  */
 class Preferences {
 	const OPTION_NAME = 'proxy';


### PR DESCRIPTION
Adds an author archive module which adds an extra option:

![image](https://github.com/user-attachments/assets/070bff6c-2867-4855-bace-c3f548abe0b3)

When enabled this will show the Gravatar author block at the top or bottom of an author archive page. The card is added before or after the main content, so should be placed inside the post content area.

Closes #89

## Testing instructions

- Enable option from discussions page
- View author archive page and check the Gravatar card is shown and is appropriate for the author