### PR TITLE
Fix block on author page when no posts

### DIFF
--- a/src/block/render.php
+++ b/src/block/render.php
@@ -34,6 +34,17 @@ if ( $attributes['userType'] === 'author' ) {
 			// We are overriding any email that was passed in the attributes
 			$email = get_the_author_meta( 'user_email', (int) $author_id );
 		}
+	} elseif ( is_author() ) {
+		// If we are on an author archive page, get the email from the author details
+		$author_id = get_query_var( 'author' );
+
+		if ( $author_id ) {
+			$author_email = get_the_author_meta( 'user_email', $author_id );
+
+			if ( $author_email ) {
+				$email = $author_email;
+			}
+		}
 	}
 }
 

--- a/src/block/view.ts
+++ b/src/block/view.ts
@@ -49,11 +49,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			return;
 		}
 
-		const { error, data } = await fetchProfile( hashedEmail );
+		const { errorCode, errorMsg, data } = await fetchProfile( hashedEmail );
 
-		if ( error ) {
+		if ( errorCode ) {
 			block.innerHTML += `
-				<div class="gravatar-block__status">${ error }</div>
+				<div class="gravatar-block__status">${ errorMsg }</div>
 			`;
 
 			return;

--- a/tests/bootstrap-common.php
+++ b/tests/bootstrap-common.php
@@ -11,3 +11,4 @@ require_once ROOT_DIR . '/classes/options/class-saved-options.php';
 require_once ROOT_DIR . '/classes/avatar/class-avatar-options.php';
 require_once ROOT_DIR . '/classes/proxy/class-proxy-options.php';
 require_once ROOT_DIR . '/classes/analytics/class-analytics-options.php';
+require_once ROOT_DIR . '/classes/class-module.php';


### PR DESCRIPTION
The Gravatar block has an 'author' option that displays the current author. If this is used on the authors archive page it displays the author being viewed, unless the author has no posts.

This adds an extra clause in the block render so it detects if it's on an author page and uses the author query var instead.

It also fixes the block JS that was incorrectly handling an error.

Fixes #101

# Testing

`yarn build` to build the plugin

- Enable the 'Author archive' option from the Settings > Discussion page
- Comment out the `render.php` changes and view the author archive of an author with no posts (i.e. `http://yoursite.com/author/john`). Confirm that no JS error appears in the console, and the block is shown with an error message
- Revert the `render.php` changes and view the same page. Confirm the block now shows the card for the author
- View an author archive for a user with posts and confirm it still works
- Insert the Gravatar block into a standard post and set the block to 'author'. View the post and confirm it still shows the post author