### PR TITLE
Pass translations to @gravatar-com/hovercards library

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -3,6 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced;
 
 require_once __DIR__ . '/class-module.php';
+require_once __DIR__ . '/shared/class-hovercards-i18n.php';
 require_once __DIR__ . '/options/class-discussions.php';
 require_once __DIR__ . '/email/class-email.php';
 require_once __DIR__ . '/hovercards/class-hovercards.php';

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -3,6 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 
 use Automattic\Gravatar\GravatarEnhanced\Module;
+use Automattic\Gravatar\GravatarEnhanced\Shared\HovercardsI18n;
 
 require_once __DIR__ . '/class-comments-options.php';
 require_once __DIR__ . '/class-comments-preferences.php';
@@ -122,6 +123,7 @@ class Comments implements Module {
 
 		$comment_data = [
 			'locale' => $this->get_gravatar_locale( get_locale() ),
+			'hovercardsI18n' => HovercardsI18n::get_translations(),
 		];
 
 		// Check if user is logged in

--- a/classes/hovercards/class-hovercards.php
+++ b/classes/hovercards/class-hovercards.php
@@ -3,6 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Hovercards;
 
 use Automattic\Gravatar\GravatarEnhanced\Module;
+use Automattic\Gravatar\GravatarEnhanced\Shared\HovercardsI18n;
 
 class Hovercards implements Module {
 	/**
@@ -110,6 +111,7 @@ class Hovercards implements Module {
 			$assets = file_exists( $asset_file ) ? require $asset_file : [ 'dependencies' => [], 'version' => time() ];
 
 			wp_enqueue_script( 'gravatar-enhanced-hovercards', plugins_url( 'build/hovercards.js', GRAVATAR_ENHANCED_PLUGIN_FILE ), $assets['dependencies'], $assets['version'], true );
+			wp_localize_script( 'gravatar-enhanced-hovercards', 'gravatarEnhancedHovercardsI18n', HovercardsI18n::get_translations() );
 			wp_register_style( 'gravatar-enhanced-hovercards', plugins_url( 'build/style-hovercards.css', GRAVATAR_ENHANCED_PLUGIN_FILE ), [], $assets['version'] );
 			wp_enqueue_style( 'gravatar-enhanced-hovercards' );
 		}

--- a/classes/quick-editor/class-quick-editor.php
+++ b/classes/quick-editor/class-quick-editor.php
@@ -3,6 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\QuickEditor;
 
 use Automattic\Gravatar\GravatarEnhanced\Module;
+use Automattic\Gravatar\GravatarEnhanced\Shared\HovercardsI18n;
 use WP_User;
 
 class QuickEditor implements Module {
@@ -312,6 +313,7 @@ HTML;
 				'otherUnknownTitle' => __( 'Profile name', 'gravatar-enhanced' ),
 				'otherUnknownDescription' => __( 'This site uses Gravatar for managing avatars and profiles.', 'gravatar-enhanced' ),
 			],
+			'hovercardsI18n' => HovercardsI18n::get_translations(),
 		];
 
 		$asset_file = dirname( GRAVATAR_ENHANCED_PLUGIN_FILE ) . '/build/quick-editor.asset.php';

--- a/classes/shared/class-hovercards-i18n.php
+++ b/classes/shared/class-hovercards-i18n.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\Gravatar\GravatarEnhanced\Shared;
+
+class HovercardsI18n {
+	/**
+	 * Returns the i18n translations for the @gravatar-com/hovercards library.
+	 *
+	 * Keys must match the English strings used as lookup keys in the library's __t() function.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_translations() {
+		return [
+			'View profile →'      => __( 'View profile →', 'gravatar-enhanced' ),
+			'Edit your profile →' => __( 'Edit your profile →', 'gravatar-enhanced' ),
+			'Contact'             => __( 'Contact', 'gravatar-enhanced' ),
+			'Send money'          => __( 'Send money', 'gravatar-enhanced' ),
+			'Email'               => __( 'Email', 'gravatar-enhanced' ),
+			'Home Phone'          => __( 'Home Phone', 'gravatar-enhanced' ),
+			'Work Phone'          => __( 'Work Phone', 'gravatar-enhanced' ),
+			'Cell Phone'          => __( 'Cell Phone', 'gravatar-enhanced' ),
+			'Contact Form'        => __( 'Contact Form', 'gravatar-enhanced' ),
+			'Calendar'            => __( 'Calendar', 'gravatar-enhanced' ),
+			'Sorry, we are unable to load this Gravatar profile.' => __( 'Sorry, we are unable to load this Gravatar profile.', 'gravatar-enhanced' ),
+			'Gravatar not found.' => __( 'Gravatar not found.', 'gravatar-enhanced' ),
+			'Too Many Requests.'  => __( 'Too Many Requests.', 'gravatar-enhanced' ),
+			'Internal Server Error.' => __( 'Internal Server Error.', 'gravatar-enhanced' ),
+			'Is this you?'        => __( 'Is this you?', 'gravatar-enhanced' ),
+			'Claim your free profile.' => __( 'Claim your free profile.', 'gravatar-enhanced' ),
+		];
+	}
+}

--- a/classes/woocommerce/class-admin-customers.php
+++ b/classes/woocommerce/class-admin-customers.php
@@ -3,6 +3,7 @@
 namespace Automattic\Gravatar\GravatarEnhanced\Woocommerce;
 
 use Automattic\Gravatar\GravatarEnhanced\Module;
+use Automattic\Gravatar\GravatarEnhanced\Shared\HovercardsI18n;
 
 class AdminCustomers implements Module {
 	/**
@@ -63,6 +64,7 @@ class AdminCustomers implements Module {
 				$assets['version'],
 				true
 			);
+			wp_localize_script( 'gravatar-enhanced-wc-admin-customers', 'gravatarEnhancedWcAdminCustomersI18n', HovercardsI18n::get_translations() );
 
 			wp_enqueue_style(
 				'gravatar-enhanced-wc-admin-customers',

--- a/src/comments/index.ts
+++ b/src/comments/index.ts
@@ -20,6 +20,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	let quickEditor = null;
 
 	const hovercards = new Hovercards( {
+		i18n: gravatarEnhancedComments?.hovercardsI18n || {},
 		onCanShowHovercard: () => {
 			return quickEditor === null || ! quickEditor.isOpen();
 		},

--- a/src/hovercards/index.ts
+++ b/src/hovercards/index.ts
@@ -4,7 +4,9 @@ import '@gravatar-com/hovercards/dist/style.css';
 const ignoreSelector = '#wpadminbar img, img.gravatar-hovercard__avatar, .user-profile-picture img';
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const hovercards = new Hovercards();
+	const hovercards = new Hovercards( {
+		i18n: typeof gravatarEnhancedHovercardsI18n !== 'undefined' ? gravatarEnhancedHovercardsI18n : {},
+	} );
 
 	hovercards.attach( document.body, { ignoreSelector } );
 } );

--- a/src/quick-editor/check-user-profile.ts
+++ b/src/quick-editor/check-user-profile.ts
@@ -7,6 +7,8 @@ import type { ProfileData } from '@gravatar-com/hovercards';
 
 const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
 
+let hovercardI18n: Record< string, string > = {};
+
 function createHovercard( user: ProfileData ) {
 	const container = document.querySelector( '.gravatar-hovercard-container' );
 	const loadingHovercard = document.querySelectorAll( '.gravatar-profile__loading' );
@@ -15,7 +17,7 @@ function createHovercard( user: ProfileData ) {
 		return;
 	}
 
-	const hovercard = Hovercards.createHovercard( user );
+	const hovercard = Hovercards.createHovercard( user, { i18n: hovercardI18n } );
 
 	// Replace PHP hovercard with JS hovercard
 	loadingHovercard.forEach( ( el ) => {
@@ -105,7 +107,9 @@ async function fetchUserProfile( hash, avatar, text, canEdit ) {
 	}
 }
 
-export default function checkUserProfile( { locale, email, hash, avatar, text, canEdit }: QuickEditor ) {
+export default function checkUserProfile( { locale, email, hash, avatar, text, canEdit, hovercardsI18n }: QuickEditor ) {
+	hovercardI18n = hovercardsI18n || {};
+
 	const container = document.querySelector( '.gravatar-profile__loading' );
 	if ( ! container ) {
 		return;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,9 +9,12 @@ interface GravatarAPIAccount {
 }
 
 declare global {
+	type HovercardsI18n = Record<string, string>;
+
 	interface GravatarEnhancedComments {
 		locale: string;
 		email?: string;
+		hovercardsI18n?: HovercardsI18n;
 	}
 
 	interface GravatarAPIProfile {
@@ -50,6 +53,7 @@ declare global {
 		text: QuickEditorText;
 		avatar: string;
 		canEdit: boolean;
+		hovercardsI18n?: HovercardsI18n;
 	}
 
 	var geQuickEditor: QuickEditor;
@@ -59,6 +63,8 @@ declare global {
 	};
 
 	var gravatarEnhancedComments: GravatarEnhancedComments;
+	var gravatarEnhancedHovercardsI18n: HovercardsI18n | undefined;
+	var gravatarEnhancedWcAdminCustomersI18n: HovercardsI18n | undefined;
 
 	type SelectFn = typeof select;
 }

--- a/src/woocommerce/admin-customers.ts
+++ b/src/woocommerce/admin-customers.ts
@@ -67,7 +67,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	 * @return {void}
 	 */
 	function injectAvatars() {
-		const hovercards = new Hovercards();
+		const hovercards = new Hovercards( {
+			i18n: typeof gravatarEnhancedWcAdminCustomersI18n !== 'undefined' ? gravatarEnhancedWcAdminCustomersI18n : {},
+		} );
 		const table = main.querySelector< HTMLTableElement >( CUSTOMER_TABLE_SELECTOR );
 
 		if ( ! table ) {


### PR DESCRIPTION
## Description

Pass the translated strings to @gravatar-com/hovercards via i18n option of Hovercards.

**Before**
<img width="366" height="95" alt="Screenshot 2026-03-13 at 14 46 33" src="https://github.com/user-attachments/assets/a7346843-696d-407b-a84b-7495012dc24c" />
**After**
<img width="366" height="95" alt="Screenshot 2026-03-13 at 14 47 26" src="https://github.com/user-attachments/assets/81979776-1f40-4eff-afef-8c3afc7bbda0" />


## Testing instructions

1. Switch the user admin language to a popular non-English locale, like Spanish or Japanese and sandbox a site.
2. Go to /wp-admin/profile.php to confirm that the "View Profile" string in the card is not translated.
3. Build the plugin release and sync it to the sandbox.
4. Check the profile page again and confirm that the card is translated now.

