### PR TITLE
Hovercards: Upgrade dependency to latest version

### DIFF
--- a/classes/shared/class-hovercards-i18n.php
+++ b/classes/shared/class-hovercards-i18n.php
@@ -24,6 +24,7 @@ class HovercardsI18n {
 			'Calendar'            => __( 'Calendar', 'gravatar-enhanced' ),
 			'Sorry, we are unable to load this Gravatar profile.' => __( 'Sorry, we are unable to load this Gravatar profile.', 'gravatar-enhanced' ),
 			'Gravatar not found.' => __( 'Gravatar not found.', 'gravatar-enhanced' ),
+			'This profile is private.' => __( 'This profile is private.', 'gravatar-enhanced' ),
 			'Too Many Requests.'  => __( 'Too Many Requests.', 'gravatar-enhanced' ),
 			'Internal Server Error.' => __( 'Internal Server Error.', 'gravatar-enhanced' ),
 			'Is this you?'        => __( 'Is this you?', 'gravatar-enhanced' ),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
-		"@gravatar-com/hovercards": "^0.15.0",
+		"@gravatar-com/hovercards": "^0.16.0",
 		"@gravatar-com/quick-editor": "^0.8.0",
 		"@wordpress/editor": "^14.32.0",
 		"@wordpress/url": "^4.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,10 +1484,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@gravatar-com/hovercards@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.15.0.tgz#c3d94a4796568ce91282a891e05b2aa14a720155"
-  integrity sha512-ASd6TbYDbBI3Jqh4iQkXSx57CleP43edo2UxosQVHIqDFm7fq26TV7B0TZVK80QNiaq5z03GMYtnSHMSR9hyoA==
+"@gravatar-com/hovercards@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@gravatar-com/hovercards/-/hovercards-0.16.0.tgz#1a460a4d34bfe75ac3ecf418f18242b36ce63db2"
+  integrity sha512-NOB73YXOUALYyqLD8SeiQkKgwrmG8wYeVz8JfqFXiH5NjAt/0iDI0pC4TL/Cqxew3XaDmGUFhXEun7mzopaaCw==
 
 "@gravatar-com/quick-editor@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## Description

Updates `@gravatar-com/hovercards` -> `0.16.0`: https://github.com/Automattic/gravatar/releases/tag/hovercards-0.16.0

## Testing instructions

1. `composer install`
2. `yarn install`
3. `yarn build`
4. Activate the plugin, e.g.:
   * in Playground,
   * via Docker and `npx @wordpress/env start`, or
   * clone this repo to an existing WordPress installation directly or via symlink
5. Create a comment with an email address of yours that has a Gravatar.
6. Approve the comment.
7. See that the hovercard works.
8. Change that Gravatar profile to be private: https://gravatar.com/profile?modal=account-settings&path=privacy
9. Reload the test site, see that the hovercard shows "This profile is private."