### PR TITLE
Fix has_gravatar() returning true on HTTP failure

### DIFF
--- a/classes/email/class-email.php
+++ b/classes/email/class-email.php
@@ -95,9 +95,14 @@ class EmailNotification implements Module {
 		$request = new WP_Http();
 		$result = $request->request( $url, array( 'method' => 'GET' ) );
 
+		// If the request failed, assume no gravatar
+		if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+			return false;
+		}
+
 		// If gravatar returns a 404, email doesn't have a gravatar attached
 		// @phpstan-ignore-next-line
-		if ( is_array( $result ) && isset( $result['response']['code'] ) && $result['response']['code'] == 404 ) {
+		if ( isset( $result['response']['code'] ) && $result['response']['code'] == 404 ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

- `has_gravatar()` treated failed HTTP requests (`WP_Error`) as "has gravatar", silently skipping invitation emails whenever the Gravatar API was unreachable (network issues, timeouts, etc.)
- Return `false` on failure instead, so invitations are still sent when we can't confirm a gravatar exists
- Removed the now-redundant `is_array()` guard on the 404 check

## Test plan

- [ ] Run integration tests: `npx @wordpress/env run tests-cli --env-cwd=wp-content/plugins/gravatar-enhanced vendor/bin/phpunit -c phpunit-integration.xml`
- [ ] Run unit tests: `composer test-unit`
- [ ] Verify invitation emails are sent when Gravatar API is unreachable