### PR TITLE
Update "Tested up to" to 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Gravatar Enhanced - Avatars, Profiles, and Privacy ===
 Contributors: automattic, batmoo, johnny5, aaronfc, wellyshen
 Tags: avatar, profile, privacy, comments, profile picture
-Tested up to: 6.8
+Tested up to: 7.0
 Stable tag: 0.13.1
 License: GPLv2
 


### PR DESCRIPTION
## Summary

- Update the "Tested up to" field in readme.txt from 6.8 to 7.0
- Plugin has been tested against the latest WordPress 7.0 development build (RC1 is scheduled for 2026-03-19)

## Test plan

- [ ] Verify readme.txt displays correct "Tested up to" version on wp.org after merge