### PR TITLE
Fix critical npm alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
 		"js-sha256": "^0.11.1",
 		"lodash.debounce": "^4.0.8"
 	},
+	"resolutions": {
+		"basic-ftp": "5.2.1",
+		"form-data": "4.0.4"
+	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,10 +5102,10 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-basic-ftp@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.5.tgz#14a474f5fffecca1f4f406f1c26b18f800225ac0"
-  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
+basic-ftp@5.2.1, basic-ftp@^5.0.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.1.tgz#818ba176e0e52a9e746e8576331f7e9474b94668"
+  integrity sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==
 
 batch@0.6.1:
   version "0.6.1"
@@ -7305,14 +7305,15 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
-form-data@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
-  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+form-data@4.0.4, form-data@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 forwarded@0.2.0:


### PR DESCRIPTION
## Summary
- Add Yarn resolutions for vulnerable transitive dev dependencies: `basic-ftp@5.2.1` and `form-data@4.0.4`.
- Refresh `yarn.lock` so the critical Dependabot alerts resolve.
- Dependabot security updates are enabled for this repo.

## Validation
- `yarn install --ignore-scripts --frozen-lockfile --non-interactive`
- `yarn audit --level critical --json` summary reported 0 critical findings
- `yarn list --pattern "basic-ftp|form-data"`
- `yarn build`
- `git diff --check`

Known existing gaps:
- `yarn lint:js` fails on existing issues in untouched files.
- `yarn lint:css` fails on existing stylelint issues in untouched files.
- The current `.nvmrc` is older than the installed `release-it` engine range, so validation used Node 22.