### PR TITLE
Fix fatal on uninstall: guard version constant

### DIFF
--- a/classes/options/class-saved-options.php
+++ b/classes/options/class-saved-options.php
@@ -107,7 +107,7 @@ class SavedOptions {
 		// Save to database
 		$options = array_merge(
 			[
-				self::OPTION_VERSION => GRAVATAR_ENHANCED_VERSION,
+				self::OPTION_VERSION => defined( 'GRAVATAR_ENHANCED_VERSION' ) ? GRAVATAR_ENHANCED_VERSION : '',
 			],
 			$this->options,
 		);

--- a/tests/unit/classes/options/class-saved-options-test.php
+++ b/tests/unit/classes/options/class-saved-options-test.php
@@ -21,4 +21,16 @@ class SavedOptionsTest extends TestCase {
 		// Act.
 		new Options\SavedOptions( 'some', false );
 	}
+
+	public function testSave() {
+		// Setup
+		\Brain\Monkey\Functions\expect( 'get_option' )->never();
+		$options = new Options\SavedOptions( 'some', false );
+
+		// Expect
+		\Brain\Monkey\Functions\expect( 'update_option' )->once()->with( 'some', [ 'version' => GRAVATAR_ENHANCED_VERSION ], false );
+
+		// Act
+		$options->save();
+	}
 }


### PR DESCRIPTION
## Description

Fixes #118

Uninstalling the plugin threw a fatal error: `SavedOptions::save()` referenced `GRAVATAR_ENHANCED_VERSION` directly, but the main plugin file is not loaded on the uninstall path, so the constant is undefined. PHP 8 throws an `Error` for undefined constants, which aborts uninstall before any option cleanup happens.

The fix guards the constant with `defined()` and falls back to an empty string. It lives in `save()`, which is the shared method used by every call site (Plugin constructor and Migrate), so all paths are covered. The version value is only ever written, never read, so an empty fallback during uninstall is harmless.

## Testing instructions

1. Build the plugin with `yarn run release`.
2. Activate the plugin on a test site, then deselect the settings options so the plugin uninstalls in a "fresh" state:
   `wp db query "DELETE FROM wp_options WHERE option_name IN ('gravatar_enhanced_options','gravatar_enhanced_options_lazy');"`
3. Uninstall the plugin either with `wp plugin uninstall gravatar-enhanced` or via the Plugins page.

Expected result: the plugin is removed without a PHP fatal, and no `gravatar_enhanced_options*` rows are left behind.

Also verifies the normal path still stores the version: unit tests and `composer test-unit` pass, including the new `testSave()` which covers `save()`.
