### PR TITLE
Fix HTML entities shown encoded in the editor profile block

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@gravatar-com/hovercards": "^0.16.0",
 		"@gravatar-com/quick-editor": "^0.8.0",
 		"@wordpress/editor": "^14.32.0",
+		"@wordpress/html-entities": "^4.32.0",
 		"@wordpress/url": "^4.32.0",
 		"clsx": "^2.1.1",
 		"js-sha256": "^0.11.1",

--- a/src/block/utils/fetch-profile.ts
+++ b/src/block/utils/fetch-profile.ts
@@ -1,3 +1,4 @@
+import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -8,6 +9,19 @@ interface Response {
 }
 
 const BASE_API_URL = 'https://api.gravatar.com/v3/profiles';
+
+// Gravatar returns the text fields as HTML-encoded strings (e.g. `&amp;`).
+// Decode them once so the editor and the view get plain text to render.
+function decodeProfileFields( profile: GravatarAPIProfile ): GravatarAPIProfile {
+	return {
+		...profile,
+		display_name: decodeEntities( profile.display_name ?? '' ),
+		description: decodeEntities( profile.description ?? '' ),
+		job_title: decodeEntities( profile.job_title ?? '' ),
+		company: decodeEntities( profile.company ?? '' ),
+		location: decodeEntities( profile.location ?? '' ),
+	};
+}
 
 export default async function fetchProfile( hashedEmail: string ): Promise< Response > {
 	try {
@@ -22,7 +36,7 @@ export default async function fetchProfile( hashedEmail: string ): Promise< Resp
 		const data = await res.json();
 		const profileUrl = addQueryArgs( data.profile_url, { utm_source: source } );
 
-		return { data: { ...data, profile_url: profileUrl } };
+		return { data: { ...decodeProfileFields( data ), profile_url: profileUrl } };
 	} catch ( code ) {
 		let message = __( 'Sorry, we are unable to load this Gravatar profile.', 'gravatar-enhanced' );
 


### PR DESCRIPTION
## Description

The profile block showed the "about me" text with HTML entities encoded in the block editor, for example `&amp;`, `&quot;` and `&gt;` instead of the plain characters. The same text rendered correctly on the front-end.

Root cause: the Gravatar API returns the profile text fields as HTML-encoded strings. The front-end path decoded them implicitly when the block HTML is set via `innerHTML`, but the editor path passed the encoded string straight into React, which escaped it again.

Fix: `fetchProfile` now decodes HTML entities once on the returned profile (`display_name`, `description`, `job_title`, `company`, `location`). Both the editor and the front-end consume the same decoded profile, so each side renders plain text and the two stay in sync.

Fixes #111

## Testing instructions

1. Build a test copy with `yarn dist` and install `dist/gravatar-enhanced.zip` on a WordPress site.
2. Insert a Gravatar block (author or custom email) in a post.
3. Set the profile's "about me" to something like `Description & things "here>` and save it on Gravatar.
4. In the block editor the profile block now shows `Description & things "here>` instead of `Description &amp; things &quot;here&gt;`.
5. Save the post and check the front-end. The text renders the same way, no doubled entities.
6. Repeat with a job title, company and location that contain `&`, `"` or other special characters.
7. Check the other block layouts (default, portrait, line) and both profile link settings to confirm nothing else changed.

Unit tests still pass (`composer test-unit`, 13 tests).
