### PR TITLE
fix(profile-block): tint verified account icons with text color

### DIFF
--- a/TESTING_INSTRUCTIONS.md
+++ b/TESTING_INSTRUCTIONS.md
@@ -1,0 +1,58 @@
+# Testing Instructions - Issue #29
+
+Synchronize the verified-account icon color with the block's text color.
+
+## Install
+
+1. Checkout the branch and build the plugin:
+
+```bash
+git checkout fix/29-sync-verified-accounts-icon-color
+yarn install
+yarn build
+```
+
+2. Copy the plugin folder into `wp-content/plugins/` of a WordPress site (PHP >= 7.4, WordPress >= 6.6):
+   - either link `gravatar-enhanced` from this repo into `wp-content/plugins/`, or
+   - run `yarn release` and copy the resulting `release/` folder into `wp-content/plugins/gravatar-enhanced/`.
+
+3. Activate "Gravatar Enhanced" from the Plugins screen.
+
+## Test Steps
+
+Requires a profile with verified accounts (social links). Add one via gravatar.com, or use a theme/plugin that supplies an author email with verified accounts.
+
+1. Create/edit a post and insert the **Gravatar Profile** block (Editor > block inserter).
+   - Set the user/email to a profile that has verified social accounts.
+   - Pick the Default or Portrait layout.
+
+2. **Set a custom text color:**
+   - With the block selected, open the block settings sidebar > Color > Text color.
+   - Pick a light color (e.g. cyan) and set the block or page background to a dark color.
+   - Check the published page:
+     - The verified-account icons (including the Gravatar marker) now render as solid silhouettes in the **chosen text color**, matching the text.
+     - The avatar photo is unchanged (still a photo, never a silhouette).
+     - Link still opens the account's profile in a new tab.
+
+3. **Set a preset text color:**
+   - Pick a theme text-color preset (e.g. white) instead of a custom swatch.
+   - Check the published page: icons match that preset color too.
+
+4. **Remove the custom color:**
+   - Clear the text color selection.
+   - Check the published page: icons return to the original brand-color SVGs, exactly as before this change.
+
+5. **Portrait layout:**
+   - Switch the block to Portrait and repeat steps 2-4. Verified-accounts group icons behave the same.
+
+6. **No regression on the avatar and text:**
+   - Confirm the avatar (image), display name, job title, company, location, description, and "View profile" link look exactly like before in both default and portrait layouts.
+
+7. **Console check:**
+   - Open the browser console on the published page. No CORS or script errors should appear.
+
+8. **Cross-check quickly in Firefox** (and Safari if available) for the same behavior.
+
+## Expected Result
+
+With a custom/preset text color set, verified-account icons use that exact color. With no custom color set, behavior is unchanged (original icons, no masking). The avatar is never masked.

--- a/src/block/render.php
+++ b/src/block/render.php
@@ -4,6 +4,7 @@
  * @var array{
  *   userEmail?: string,
  *   textColor?: string,
+ *   style?: array{ color?: array{ text?: string } },
  *   userType: string,
  *   layout: string,
  *   avatarUrlSizeParam: string,
@@ -63,7 +64,7 @@ $layout_class_map = [
 	'line' => 'gravatar-block--line',
 ];
 $layout_class = isset( $layout_class_map[ $attributes['layout'] ] ) ? ' ' . $layout_class_map[ $attributes['layout'] ] : '';
-$custom_text_color_class = isset( $attributes['textColor'] ) ? ' gravatar-block--custom-text-color' : '';
+$custom_text_color_class = isset( $attributes['textColor'] ) || isset( $attributes['style']['color']['text'] ) ? ' gravatar-block--custom-text-color' : '';
 $class = 'gravatar-block' . $layout_class . $custom_text_color_class;
 
 $data = wp_json_encode(

--- a/src/block/shared-types.ts
+++ b/src/block/shared-types.ts
@@ -65,6 +65,7 @@ export type GroupAttrs = Partial< {
 export interface ImageAttrs {
 	linkUrl?: string;
 	imageUrl: string;
+	serviceIcon?: string;
 	imageWidth: number;
 	imageHeight: number;
 	imageAlt: string;

--- a/src/block/shared.scss
+++ b/src/block/shared.scss
@@ -3,12 +3,12 @@
 $font:
 	"SF Pro Text",
 	-apple-system,
-	BlinkMacSystemFont,
+	blinkmacsystemfont,
 	"Segoe UI",
-	Roboto,
-	Oxygen-Sans,
-	Ubuntu,
-	Cantarell,
+	roboto,
+	oxygen-sans,
+	ubuntu,
+	cantarell,
 	"Helvetica Neue",
 	sans-serif;
 
@@ -27,14 +27,17 @@ $color-gray: #50575e;
 }
 
 .gravatar-text-truncate-1-line {
+
 	@include text-truncate(1);
 }
 
 .gravatar-text-truncate-2-lines {
+
 	@include text-truncate(2);
 }
 
 .gravatar-text-truncate-3-lines {
+
 	@include text-truncate(3);
 }
 
@@ -72,6 +75,7 @@ div.wp-block-gravatar-block.gravatar-block {
 	}
 
 	.gravatar-block-group {
+
 		&.gravatar-block-group--comma-separated .gravatar-block-paragraph {
 			display: flex;
 
@@ -81,6 +85,7 @@ div.wp-block-gravatar-block.gravatar-block {
 			}
 
 			.gravatar-block-paragraph__text {
+
 				@include text-truncate(1);
 			}
 		}
@@ -141,6 +146,7 @@ div.wp-block-gravatar-block.gravatar-block {
 	}
 
 	&.gravatar-block--custom-text-color {
+
 		h4,
 		p,
 		.gravatar-block-paragraph--job .gravatar-block-paragraph__text,
@@ -148,6 +154,27 @@ div.wp-block-gravatar-block.gravatar-block {
 		.gravatar-block-paragraph--location .gravatar-block-paragraph__text,
 		.gravatar-block-link {
 			color: unset;
+		}
+
+		// Verified account icons are served as monochrome SVGs, so they can't be recolored via the image.
+		// Mask the wrapper and tint it with the text color instead. The image is hidden so its own fill
+		// doesn't paint over the tinted wrapper.
+		.gravatar-block-image--account {
+			width: 32px;
+			height: 32px;
+			background-color: currentcolor;
+			mask-image: var(--gravatar-icon-url);
+			-webkit-mask-image: var(--gravatar-icon-url);
+			mask-repeat: no-repeat;
+			-webkit-mask-repeat: no-repeat;
+			mask-size: contain;
+			-webkit-mask-size: contain;
+			mask-position: center;
+			-webkit-mask-position: center;
+
+			.gravatar-block-image__image {
+				display: none;
+			}
 		}
 	}
 
@@ -177,6 +204,7 @@ div.wp-block-gravatar-block.gravatar-block--portrait {
 	}
 
 	.gravatar-block-paragraph {
+
 		&.gravatar-block-paragraph--job,
 		&.gravatar-block-paragraph--location {
 			font-size: 14px;

--- a/src/block/view-elements/get-image.ts
+++ b/src/block/view-elements/get-image.ts
@@ -5,10 +5,30 @@ import { escapeAttribute } from '@wordpress/escape-html';
 
 type Props = ImageAttrs;
 
-export default function getImage( { linkUrl, imageUrl, imageWidth, imageHeight, imageAlt, className }: Props ): string {
+export default function getImage( {
+	linkUrl,
+	imageUrl,
+	serviceIcon,
+	imageWidth,
+	imageHeight,
+	imageAlt,
+	className,
+}: Props ): string {
 	return getMaybeLink( {
 		linkUrl,
-		class: clsx( 'gravatar-block__child', 'gravatar-block-image', className ),
+		class: clsx(
+			'gravatar-block__child',
+			'gravatar-block-image',
+			serviceIcon && 'gravatar-block-image--account',
+			className
+		),
+		// Only set the extra props for account icons. The image is hidden under a custom text
+		// color, so the wrapper carries both the CSS var used as its mask and the accessible
+		// name. The URL goes inside url() unquoted so the value can't break out of the attribute.
+		...( serviceIcon && {
+			style: `--gravatar-icon-url: url(${ serviceIcon })`,
+			'aria-label': escapeAttribute( imageAlt ),
+		} ),
 		children: `<img class="gravatar-block-image__image" src="${ imageUrl }" width="${ imageWidth }" height="${ imageHeight }" alt="${ escapeAttribute(
 			imageAlt
 		) }"/>`,

--- a/src/block/view-templates/elements/get-verified-accounts.ts
+++ b/src/block/view-templates/elements/get-verified-accounts.ts
@@ -25,6 +25,7 @@ export default function getVerifiedAccounts(
 		return getViewElement( BlockNames.IMAGE, account.service_type, deletedElements, {
 			linkUrl: account.url,
 			imageUrl: account.service_icon,
+			serviceIcon: account.service_icon,
 			imageWidth: 32,
 			imageHeight: 32,
 			imageAlt: account.service_label,


### PR DESCRIPTION
## Description

Verified account icons come from the Gravatar API as images, so their color can't be changed to match the block's text color. The icons are monochrome SVGs, so instead of bundling icons or changing the API, this masks the icon wrapper with the icon URL and tints it with `currentColor` when a custom or preset text color is set. The original image is hidden while tinted and comes back when the color is cleared.

The text color detection in `render.php` now also covers custom colors stored in `style.color.text`, since the wrapper class was only added for preset colors before. On the front end, `view.ts` rebuilds the block from API data, so the icon URL is passed through as a CSS variable on the wrapper and the mask does the tinting. The wrapper also gets the icon's label as `aria-label` while the image is hidden.

Fixes #29

## Testing instructions

1. Insert a Gravatar Profile block for a profile that has verified accounts and publish the page.
2. On the published page, confirm the verified account icons render in their original colors.
3. Set a custom text color on the block and view the published page again: the icons now render as silhouettes in the text color, the avatar is unchanged, and the icon links still work.
4. Switch to a preset text color: same result.
5. Clear the text color: the original brand icons return.
6. Repeat with the Portrait layout and check there are no console errors.