### PR TITLE
feat: add Fediverse hovercard support

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -17,6 +17,8 @@ require_once __DIR__ . '/woocommerce/class-admin-customers.php';
 require_once __DIR__ . '/woocommerce/class-my-account.php';
 require_once __DIR__ . '/oembed/class-oembed.php';
 require_once __DIR__ . '/comments/class-comments.php';
+require_once __DIR__ . '/fediverse/class-fediverse.php';
+require_once __DIR__ . '/fediverse/class-fediverse-resolver.php';
 
 class Plugin {
 	const OPTION_NAME_AUTO = 'gravatar_enhanced_options';
@@ -98,6 +100,11 @@ class Plugin {
 	private $comments;
 
 	/**
+	 * @var Fediverse\Fediverse
+	 */
+	private $fediverse;
+
+	/**
 	 * @var Module[]
 	 */
 	private $modules;
@@ -123,6 +130,7 @@ class Plugin {
 		$this->wc_my_account = new Woocommerce\MyAccount();
 		$this->oembed = new OEmbed\OEmbed();
 		$this->comments = new Comments\Comments( new Comments\Preferences( $this->auto_options ) );
+		$this->fediverse = new Fediverse\Fediverse();
 
 		// Collect all modules and filter them based on the whitelist if available.
 		$this->modules = [
@@ -138,6 +146,7 @@ class Plugin {
 			'wc_my_account' => $this->wc_my_account,
 			'oembed' => $this->oembed,
 			'comments' => $this->comments,
+			'fediverse' => $this->fediverse,
 		];
 
 		$modules_whitelist = apply_filters( 'gravatar_enhanced_modules_whitelist', null );

--- a/classes/comments/class-comments-options.php
+++ b/classes/comments/class-comments-options.php
@@ -5,17 +5,23 @@ namespace Automattic\Gravatar\GravatarEnhanced\Comments;
 /**
  * @phpstan-type CommentsOptionsArray = array{
  *   enabled: bool,
+ *   fediverse_hovercards: bool,
  * }
  */
 class Options {
 	/** @var bool */
 	public $enabled;
 
+	/** @var bool */
+	public $fediverse_hovercards;
+
 	/**
 	 * @param bool $enabled
+	 * @param bool $fediverse_hovercards
 	 */
-	public function __construct( $enabled ) {
-		$this->enabled = $enabled;
+	public function __construct( $enabled, $fediverse_hovercards ) {
+		$this->enabled             = $enabled;
+		$this->fediverse_hovercards = $fediverse_hovercards;
 	}
 
 	/**
@@ -23,7 +29,8 @@ class Options {
 	 */
 	public function to_array() {
 		return [
-			'enabled' => $this->enabled,
+			'enabled'              => $this->enabled,
+			'fediverse_hovercards' => $this->fediverse_hovercards,
 		];
 	}
 
@@ -32,6 +39,9 @@ class Options {
 	 * @return Options
 	 */
 	public static function from_array( $options ) {
-		return new Options( $options['enabled'] );
+		return new Options(
+			$options['enabled'],
+			$options['fediverse_hovercards']
+		);
 	}
 }

--- a/classes/comments/class-comments-preferences.php
+++ b/classes/comments/class-comments-preferences.php
@@ -36,7 +36,8 @@ class Preferences {
 	 */
 	private function get_default_options() {
 		return [
-			'enabled' => true,
+			'enabled'              => true,
+			'fediverse_hovercards' => true,
 		];
 	}
 

--- a/classes/comments/class-comments.php
+++ b/classes/comments/class-comments.php
@@ -139,6 +139,29 @@ class Comments implements Module {
 			'gravatarEnhancedComments',
 			$comment_data
 		);
+
+		if ( $this->options->fediverse_hovercards ) {
+			$this->enqueue_fediverse_hovercards();
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	private function enqueue_fediverse_hovercards() {
+		$asset_file = dirname( GRAVATAR_ENHANCED_PLUGIN_FILE ) . '/build/fediverse.asset.php';
+		$assets = file_exists( $asset_file ) ? require $asset_file : [ 'dependencies' => [], 'version' => time() ];
+
+		wp_enqueue_script( 'gravatar-enhanced-fediverse', plugins_url( 'build/fediverse.js', GRAVATAR_ENHANCED_PLUGIN_FILE ), $assets['dependencies'], $assets['version'], true );
+
+		wp_localize_script(
+			'gravatar-enhanced-fediverse',
+			'gravatarEnhancedFediverse',
+			[
+				'enabled' => true,
+				'restUrl' => get_rest_url(),
+			]
+		);
 	}
 
 	/**

--- a/classes/fediverse/class-fediverse-resolver.php
+++ b/classes/fediverse/class-fediverse-resolver.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Fediverse profile resolver.
+ *
+ * @package Automattic\Gravatar\GravatarEnhanced
+ */
+
+namespace Automattic\Gravatar\GravatarEnhanced\Fediverse;
+
+use WP_Error;
+
+/**
+ * Resolves Fediverse profile URLs via WebFinger and ActivityPub.
+ */
+class Fediverse_Resolver {
+	const TIMEOUT = 5;
+
+	const WEBFINGER_PATH = '/.well-known/webfinger';
+
+	const ACTOR_REL = 'self';
+
+	const ACTIVITYPUB_TYPE = 'application/activity+json';
+
+	/**
+	 * Resolve a Fediverse profile URL to normalized data.
+	 *
+	 * @param string $url The profile URL.
+	 * @return array{display_name: string, summary: string, avatar_url: string, profile_url: string, follow_url: string}|WP_Error
+	 */
+	public function resolve( $url ) {
+		$parsed = wp_parse_url( $url );
+		if ( ! $parsed || empty( $parsed['host'] ) ) {
+			return new WP_Error( 'fediverse_invalid_url', __( 'Invalid URL: missing host.', 'gravatar-enhanced' ), array( 'status' => 400 ) );
+		}
+
+		$host = $parsed['host'];
+		$path = isset( $parsed['path'] ) ? $parsed['path'] : '';
+
+		if ( ! empty( $path ) && '@' === $path[0] ) {
+			$acct = $this->acct_from_at_url( $url, $host, $path );
+		} elseif ( ! empty( $path ) && str_contains( $path, '/@' ) ) {
+			$acct = $this->acct_from_web_url( $host, $path );
+		} else {
+			$acct = $this->acct_from_url( $host, $path );
+		}
+
+		if ( empty( $acct ) ) {
+			return new WP_Error( 'fediverse_unsupported', __( 'Could not extract Fediverse handle from URL.', 'gravatar-enhanced' ), array( 'status' => 400 ) );
+		}
+
+		$webfinger_url = $this->build_webfinger_url( $host, $acct );
+		$response      = $this->http_get( $webfinger_url );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( empty( $body ) ) {
+			return new WP_Error( 'fediverse_webfinger_empty', __( 'WebFinger response was empty.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		$data = json_decode( $body, true );
+		if ( empty( $data ) || ! is_array( $data ) ) {
+			return new WP_Error( 'fediverse_webfinger_invalid', __( 'WebFinger response was invalid.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		$actor_url = $this->find_actor_link( $data );
+		if ( empty( $actor_url ) ) {
+			return new WP_Error( 'fediverse_no_actor', __( 'No ActivityPub actor found for this profile.', 'gravatar-enhanced' ), array( 'status' => 404 ) );
+		}
+
+		$actor = $this->fetch_actor( $actor_url );
+
+		if ( is_wp_error( $actor ) ) {
+			return $actor;
+		}
+
+		return $this->normalize_profile( $actor, $url );
+	}
+
+	/**
+	 * Extract acct: from a Mastodon-style @ URL.
+	 *
+	 * @param string $url The profile URL.
+	 * @param string $host The host.
+	 * @param string $path The path.
+	 * @return string
+	 */
+	private function acct_from_at_url( $url, $host, $path ) {
+		$path = trim( $path, '/' );
+
+		$path  = preg_replace( '/^@/', '', $path );
+		$parts = explode( '/', $path ?? '' );
+		$path  = $parts[0];
+
+		return '@' . $path . '@' . $host;
+	}
+
+	/**
+	 * Extract acct: from a web-style URL (e.g. /@user or /users/user).
+	 *
+	 * @param string $host The host.
+	 * @param string $path The path.
+	 * @return string
+	 */
+	private function acct_from_web_url( $host, $path ) {
+		$path = trim( $path, '/' );
+
+		if ( preg_match( '/^@([^\/]+)/', $path, $matches ) ) {
+			return '@' . $matches[1] . '@' . $host;
+		}
+
+		if ( preg_match( '/^users\/(.+)$/', $path, $matches ) ) {
+			return '@' . $matches[1] . '@' . $host;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract acct: from a generic URL.
+	 *
+	 * @param string $host The host.
+	 * @param string $path The path.
+	 * @return string
+	 */
+	private function acct_from_url( $host, $path ) {
+		$path = trim( $path, '/' );
+
+		if ( empty( $path ) ) {
+			return '';
+		}
+
+		$segments = explode( '/', $path );
+		$username = end( $segments );
+
+		return '@' . $username . '@' . $host;
+	}
+
+	/**
+	 * Build the WebFinger URL.
+	 *
+	 * @param string $host The host.
+	 * @param string $acct The account identifier.
+	 * @return string
+	 */
+	private function build_webfinger_url( $host, $acct ) {
+		$resource = 'acct:' . ltrim( $acct, '@' );
+
+		return 'https://' . $host . self::WEBFINGER_PATH . '?resource=' . rawurlencode( $resource );
+	}
+
+	/**
+	 * Find the ActivityPub actor link from WebFinger data.
+	 *
+	 * @param array<string, mixed> $webfinger The WebFinger response data.
+	 * @return string
+	 */
+	private function find_actor_link( $webfinger ) {
+		if ( empty( $webfinger['links'] ) || ! is_array( $webfinger['links'] ) ) {
+			return '';
+		}
+
+		foreach ( $webfinger['links'] as $link ) {
+			if ( empty( $link['rel'] ) || empty( $link['href'] ) ) {
+				continue;
+			}
+
+			if ( self::ACTOR_REL === $link['rel'] && ! empty( $link['type'] ) && self::ACTIVITYPUB_TYPE === $link['type'] ) {
+				return esc_url_raw( $link['href'] );
+			}
+		}
+
+		foreach ( $webfinger['links'] as $link ) {
+			if ( empty( $link['rel'] ) || empty( $link['href'] ) ) {
+				continue;
+			}
+
+			if ( self::ACTOR_REL === $link['rel'] ) {
+				return esc_url_raw( $link['href'] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fetch the ActivityPub actor JSON.
+	 *
+	 * @param string $actor_url The actor URL.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function fetch_actor( $actor_url ) {
+		$response = wp_remote_get(
+			$actor_url,
+			array(
+				'timeout' => self::TIMEOUT,
+				'headers' => array(
+					'Accept' => 'application/activity+json, application/ld+json',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			return new WP_Error( 'fediverse_actor_error', __( 'Failed to fetch ActivityPub actor.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( empty( $body ) ) {
+			return new WP_Error( 'fediverse_actor_empty', __( 'ActivityPub actor response was empty.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		$data = json_decode( $body, true );
+		if ( empty( $data ) || ! is_array( $data ) ) {
+			return new WP_Error( 'fediverse_actor_invalid', __( 'ActivityPub actor response was invalid.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Normalize the ActivityPub actor data into a profile array.
+	 *
+	 * @param array<string, mixed> $actor The actor data.
+	 * @param string               $original_url The original requested URL.
+	 * @return array{display_name: string, summary: string, avatar_url: string, profile_url: string, follow_url: string}
+	 */
+	private function normalize_profile( $actor, $original_url ) {
+		$display_name = '';
+		if ( ! empty( $actor['name'] ) ) {
+			$display_name = sanitize_text_field( $actor['name'] );
+		} elseif ( ! empty( $actor['preferredUsername'] ) ) {
+			$display_name = sanitize_text_field( $actor['preferredUsername'] );
+		}
+
+		$summary = '';
+		if ( ! empty( $actor['summary'] ) ) {
+			$summary = wp_kses_post( $actor['summary'] );
+		}
+
+		$avatar_url = '';
+		if ( ! empty( $actor['icon']['url'] ) ) {
+			$avatar_url = esc_url_raw( $actor['icon']['url'] );
+		}
+
+		$profile_url = '';
+		if ( ! empty( $actor['url'] ) ) {
+			$profile_url = esc_url_raw( $actor['url'] );
+		} else {
+			$profile_url = esc_url_raw( $original_url );
+		}
+
+		$follow_url = '';
+		if ( ! empty( $actor['id'] ) ) {
+			$follow_url = esc_url_raw( $actor['id'] );
+		}
+
+		return array(
+			'display_name' => $display_name,
+			'summary'      => $summary,
+			'avatar_url'   => $avatar_url,
+			'profile_url'  => $profile_url,
+			'follow_url'   => $follow_url,
+		);
+	}
+
+	/**
+	 * Make an HTTP GET request.
+	 *
+	 * @param string $url The URL to fetch.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function http_get( $url ) {
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout' => self::TIMEOUT,
+				'headers' => array(
+					'Accept' => 'application/jrd+json, application/json',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			return new WP_Error( 'fediverse_http_error', __( 'HTTP error during lookup.', 'gravatar-enhanced' ), array( 'status' => 502 ) );
+		}
+
+		return $response;
+	}
+}

--- a/classes/fediverse/class-fediverse.php
+++ b/classes/fediverse/class-fediverse.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Fediverse hovercards module.
+ *
+ * @package Automattic\Gravatar\GravatarEnhanced
+ */
+
+namespace Automattic\Gravatar\GravatarEnhanced\Fediverse;
+
+use Automattic\Gravatar\GravatarEnhanced\Module;
+use WP_Error;
+
+/**
+ * Fediverse hovercards module.
+ */
+class Fediverse implements Module {
+	const OPTION_FEDIVERSE_HOVERCARDS = 'gravatar_fediverse_hovercards';
+
+	const FILTER_FEDIVERSE_MODULE_ENABLED = 'gravatar_enhanced_fediverse_module_enabled';
+
+	const REST_NAMESPACE = 'gravatar-enhanced/v1';
+
+	const REST_ROUTE_LOOKUP = '/fediverse/lookup';
+
+	/**
+	 * Initialize the module.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'init', array( $this, 'maybe_load' ) );
+	}
+
+	/**
+	 * Load the module if enabled.
+	 *
+	 * @return void
+	 */
+	public function maybe_load() {
+		if ( $this->is_module_disabled() ) {
+			return;
+		}
+
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Uninstall the module.
+	 *
+	 * @return void
+	 */
+	public function uninstall() {
+		delete_option( self::OPTION_FEDIVERSE_HOVERCARDS );
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE_LOOKUP,
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'handle_lookup' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'url' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'esc_url_raw',
+						'validate_callback' => array( $this, 'validate_url' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Validate the URL parameter.
+	 *
+	 * @param mixed            $value The value to validate.
+	 * @param \WP_REST_Request $request The request object.
+	 * @param string           $param The parameter name.
+	 * @return true|\WP_Error
+	 */
+	public function validate_url( $value, $request, $param ) { // phpcs:ignore Generic.Commenting.DocComment.TagInvalid
+		if ( ! is_string( $value ) || empty( $value ) ) {
+			return new \WP_Error( 'rest_invalid_param', __( 'URL is required.', 'gravatar-enhanced' ), array( 'status' => 400 ) );
+		}
+
+		$url = esc_url_raw( $value );
+		if ( empty( $url ) || ! wp_http_validate_url( $url ) ) {
+			return new \WP_Error( 'rest_invalid_param', __( 'Invalid URL.', 'gravatar-enhanced' ), array( 'status' => 400 ) );
+		}
+
+		$parsed = wp_parse_url( $url );
+		if ( empty( $parsed['host'] ) ) {
+			return new \WP_Error( 'rest_invalid_param', __( 'URL must contain a host.', 'gravatar-enhanced' ), array( 'status' => 400 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Handle the lookup request.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle_lookup( $request ) { // phpcs:ignore Generic.Commenting.DocComment.TagInvalid
+		$url = $request->get_param( 'url' );
+
+		$cache_key = 'gravatar_fediverse_' . md5( $url );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return rest_ensure_response( $cached );
+		}
+
+		$resolver = new Fediverse_Resolver();
+		$profile  = $resolver->resolve( $url );
+
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+
+		set_transient( $cache_key, $profile, HOUR_IN_SECONDS );
+
+		return rest_ensure_response( $profile );
+	}
+
+	/**
+	 * Check if the module is disabled.
+	 *
+	 * @return bool
+	 */
+	private function is_module_disabled() {
+		if ( ! apply_filters( self::FILTER_FEDIVERSE_MODULE_ENABLED, true ) ) {
+			return true;
+		}
+
+		if ( ! $this->is_option_enabled() ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the option is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_option_enabled() {
+		return boolval( get_option( self::OPTION_FEDIVERSE_HOVERCARDS, true ) );
+	}
+}

--- a/classes/options/class-discussions.php
+++ b/classes/options/class-discussions.php
@@ -278,6 +278,19 @@ class DiscussionsPage {
 					<?php esc_html_e( 'Show Gravatar in the comment form.', 'gravatar-enhanced' ); ?>
 				<?php endif; ?>
 			</label>
+
+			<br>
+
+			<label for="gravatar_fediverse_hovercards">
+				<input
+					type="checkbox"
+					id="gravatar_fediverse_hovercards"
+					name="gravatar_fediverse_hovercards"
+					<?php checked( $comments->fediverse_hovercards ); ?>
+				/>
+
+				<?php esc_html_e( 'Show hovercards for Fediverse profiles (Mastodon, etc.).', 'gravatar-enhanced' ); ?>
+			</label>
 		</fieldset>
 		<?php
 	}
@@ -327,7 +340,8 @@ class DiscussionsPage {
 	 */
 	private function get_comment_preferences() {
 		$options = [
-			'enabled' => isset( $_POST['gravatar_comments'] ),
+			'enabled'              => isset( $_POST['gravatar_comments'] ),
+			'fediverse_hovercards' => isset( $_POST['gravatar_fediverse_hovercards'] ),
 		];
 
 		$new_options = Comments\Options::from_array( $options );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,6 +28,12 @@ parameters:
 	reportMaybesInPropertyPhpDocTypes: false
 	reportWrongPhpDocTypeInVarTag: false
 
+	ignoreErrors:
+		-
+			message: '#has parameter \$request with generic class WP_REST_Request but does not specify its types#'
+			paths:
+				- classes/fediverse/class-fediverse.php
+
 	parallel:
 		maximumNumberOfProcesses: 4
 

--- a/src/fediverse/index.ts
+++ b/src/fediverse/index.ts
@@ -1,0 +1,286 @@
+import './style.scss';
+
+interface FediverseProfile {
+	display_name: string;
+	summary: string;
+	avatar_url: string;
+	profile_url: string;
+	follow_url: string;
+}
+
+interface FediverseCardElements {
+	wrapper: HTMLElement;
+	name: HTMLElement;
+	summary: HTMLElement;
+	avatar: HTMLImageElement;
+	link: HTMLAnchorElement;
+}
+
+const CARD_CLASS = 'gravatar-fediverse-card';
+const CARD_VISIBLE_CLASS = 'gravatar-fediverse-card--visible';
+const AVATAR_SELECTOR = 'img.avatar';
+const AUTHOR_LINK_SELECTOR = 'a.url';
+const REST_NAMESPACE = 'gravatar-enhanced/v1';
+const REST_ROUTE = '/fediverse/lookup';
+
+let card: FediverseCardElements | null = null;
+let hideTimeout: ReturnType< typeof setTimeout > | null = null;
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	if ( ! isFediverseHovercardsEnabled() ) {
+		return;
+	}
+
+	createCard();
+	attachListeners();
+} );
+
+function isFediverseHovercardsEnabled(): boolean {
+	const settings = ( window as unknown as { gravatarEnhancedFediverse?: { enabled: boolean } } ).gravatarEnhancedFediverse;
+	return settings?.enabled !== false;
+}
+
+function createCard(): void {
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = CARD_CLASS;
+	wrapper.setAttribute( 'role', 'tooltip' );
+	wrapper.setAttribute( 'aria-hidden', 'true' );
+
+	const avatar = document.createElement( 'img' );
+	avatar.className = `${ CARD_CLASS }__avatar`;
+	avatar.alt = '';
+	avatar.width = 60;
+	avatar.height = 60;
+
+	const content = document.createElement( 'div' );
+	content.className = `${ CARD_CLASS }__content`;
+
+	const name = document.createElement( 'strong' );
+	name.className = `${ CARD_CLASS }__name`;
+
+	const summary = document.createElement( 'p' );
+	summary.className = `${ CARD_CLASS }__summary`;
+
+	const link = document.createElement( 'a' );
+	link.className = `${ CARD_CLASS }__link`;
+	link.textContent = __( 'View profile →', 'gravatar-enhanced' );
+	link.setAttribute( 'rel', 'noopener noreferrer' );
+	link.setAttribute( 'target', '_blank' );
+
+	content.appendChild( name );
+	content.appendChild( summary );
+	content.appendChild( link );
+
+	wrapper.appendChild( avatar );
+	wrapper.appendChild( content );
+	document.body.appendChild( wrapper );
+
+	card = { wrapper, name, summary, avatar, link };
+}
+
+function attachListeners(): void {
+	document.addEventListener( 'mouseover', handleMouseOver, true );
+	document.addEventListener( 'mouseout', handleMouseOut, true );
+}
+
+function handleMouseOver( event: MouseEvent ): void {
+	const target = event.target as HTMLElement;
+	const avatar = target.closest( `${ AVATAR_SELECTOR }, .avatar` ) as HTMLImageElement | null;
+
+	if ( ! avatar ) {
+		return;
+	}
+
+	const commentEl = avatar.closest( '.comment-body, .comment-content, [class*="comment"]' );
+	if ( ! commentEl ) {
+		return;
+	}
+
+	const authorLink = commentEl.querySelector( AUTHOR_LINK_SELECTOR ) as HTMLAnchorElement | null;
+	if ( ! authorLink ) {
+		return;
+	}
+
+	const url = authorLink.href;
+	if ( ! url || ! isFediverseUrl( url ) ) {
+		return;
+	}
+
+	showCard( avatar, url );
+}
+
+function handleMouseOut( event: MouseEvent ): void {
+	const target = event.target as HTMLElement;
+	const avatar = target.closest( `${ AVATAR_SELECTOR }, .avatar` ) as HTMLImageElement | null;
+
+	if ( ! avatar ) {
+		return;
+	}
+
+	scheduleHideCard();
+}
+
+function isFediverseUrl( url: string ): boolean {
+	try {
+		const parsed = new URL( url );
+		if ( ! parsed.host || parsed.host.includes( 'gravatar.com' ) ) {
+			return false;
+		}
+		if ( parsed.protocol !== 'http:' && parsed.protocol !== 'https:' ) {
+			return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function showCard( avatar: HTMLImageElement, url: string ): void {
+	if ( ! card ) {
+		return;
+	}
+
+	clearHideTimeout();
+	clearShowTimeout();
+
+	card.wrapper.setAttribute( 'aria-hidden', 'true' );
+	card.wrapper.classList.remove( CARD_VISIBLE_CLASS );
+
+	positionCard( avatar );
+	showLoadingState();
+
+	try {
+		const profile = await fetchProfile( url );
+		if ( ! profile ) {
+			hideCard();
+			return;
+		}
+
+		renderProfile( profile );
+		card.wrapper.setAttribute( 'aria-hidden', 'false' );
+		card.wrapper.classList.add( CARD_VISIBLE_CLASS );
+	} catch {
+		hideCard();
+	}
+}
+
+function showLoadingState(): void {
+	if ( ! card ) {
+		return;
+	}
+
+	card.avatar.style.opacity = '0.3';
+	card.name.textContent = '';
+	card.summary.textContent = '';
+	card.link.href = '';
+	card.link.style.display = 'none';
+}
+
+function renderProfile( profile: FediverseProfile ): void {
+	if ( ! card ) {
+		return;
+	}
+
+	card.avatar.style.opacity = '1';
+
+	if ( profile.avatar_url ) {
+		card.avatar.src = profile.avatar_url;
+		card.avatar.style.display = 'block';
+	} else {
+		card.avatar.style.display = 'none';
+	}
+
+	card.name.textContent = profile.display_name || '';
+	card.summary.textContent = profile.summary || '';
+
+	if ( profile.profile_url ) {
+		card.link.href = profile.profile_url;
+		card.link.style.display = 'inline';
+	} else {
+		card.link.style.display = 'none';
+	}
+}
+
+function hideCard(): void {
+	clearHideTimeout();
+	clearShowTimeout();
+
+	if ( ! card ) {
+		return;
+	}
+
+	card.wrapper.classList.remove( CARD_VISIBLE_CLASS );
+	card.wrapper.setAttribute( 'aria-hidden', 'true' );
+}
+
+function scheduleHideCard(): void {
+	clearHideTimeout();
+	hideTimeout = setTimeout( hideCard, 150 );
+}
+
+let showTimeout: ReturnType< typeof setTimeout > | null = null;
+
+function clearHideTimeout(): void {
+	if ( hideTimeout ) {
+		clearTimeout( hideTimeout );
+		hideTimeout = null;
+	}
+}
+
+function clearShowTimeout(): void {
+	if ( showTimeout ) {
+		clearTimeout( showTimeout );
+		showTimeout = null;
+	}
+}
+
+function positionCard( avatar: HTMLImageElement ): void {
+	if ( ! card ) {
+		return;
+	}
+
+	const rect = avatar.getBoundingClientRect();
+	const cardWidth = 280;
+	const cardHeight = 120;
+	const offset = 8;
+
+	let top = rect.top + window.scrollY - cardHeight - offset;
+	let left = rect.left + window.scrollX + rect.width / 2 - cardWidth / 2;
+
+	const viewportWidth = window.innerWidth;
+	if ( left < 8 ) {
+		left = 8;
+	} else if ( left + cardWidth > viewportWidth - 8 ) {
+		left = viewportWidth - cardWidth - 8;
+	}
+
+	if ( top < window.scrollY + 8 ) {
+		top = rect.bottom + window.scrollY + offset;
+	}
+
+	card.wrapper.style.top = `${ top }px`;
+	card.wrapper.style.left = `${ left }px`;
+}
+
+async function fetchProfile( url: string ): Promise< FediverseProfile | null > {
+	const settings = ( window as unknown as { gravatarEnhancedFediverse?: { restUrl?: string } } ).gravatarEnhancedFediverse;
+	const baseUrl = settings?.restUrl || '/wp-json';
+
+	const apiUrl = `${ baseUrl }${ REST_NAMESPACE }${ REST_ROUTE }?url=${ encodeURIComponent( url ) }`;
+
+	const response = await fetch( apiUrl, {
+		headers: {
+			Accept: 'application/json',
+		},
+	} );
+
+	if ( ! response.ok ) {
+		return null;
+	}
+
+	return response.json();
+}
+
+function __( text: string ): string {
+	return text;
+}

--- a/src/fediverse/style.scss
+++ b/src/fediverse/style.scss
@@ -1,0 +1,68 @@
+.gravatar-fediverse-card {
+	position: absolute;
+	z-index: 999999;
+	display: none;
+	box-sizing: border-box;
+	width: 280px;
+	padding: 16px;
+	background: #fff;
+	border: 1px solid #ddd;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+	font-size: 14px;
+	line-height: 1.4;
+	color: #1d2327;
+	pointer-events: auto;
+
+	&--visible {
+		display: flex;
+		gap: 12px;
+		align-items: flex-start;
+	}
+
+	&__avatar {
+		flex-shrink: 0;
+		width: 60px;
+		height: 60px;
+		border-radius: 50%;
+		object-fit: cover;
+	}
+
+	&__content {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	&__name {
+		display: block;
+		margin-bottom: 4px;
+		font-size: 16px;
+		font-weight: 600;
+		color: #1d2327;
+		word-break: break-word;
+	}
+
+	&__summary {
+		display: -webkit-box;
+		margin: 0 0 8px;
+		overflow: hidden;
+		font-size: 13px;
+		color: #50575e;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		line-clamp: 3;
+	}
+
+	&__link {
+		font-size: 13px;
+		font-weight: 500;
+		color: #1d4fc4;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/tests/unit/classes/fediverse/class-fediverse-test.php
+++ b/tests/unit/classes/fediverse/class-fediverse-test.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Tests for the Fediverse module.
+ *
+ * @package Automattic\Gravatar\GravatarEnhanced
+ */
+
+namespace Automattic\Gravatar\GravatarEnhanced\Fediverse;
+
+use GravatarEnhanced\Tests\Unit\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+require_once ROOT_DIR . '/classes/fediverse/class-fediverse.php';
+
+/**
+ * Fediverse module tests.
+ */
+class FediverseTest extends TestCase {
+
+	/**
+	 * The Fediverse instance.
+	 *
+	 * @var Fediverse
+	 */
+	private $fediverse;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->fediverse = new Fediverse();
+	}
+
+	/**
+	 * Test init adds expected hooks.
+	 *
+	 * @return void
+	 */
+	public function testInit_WhenCalled_ThenAddsExpectedInitHook() {
+		$this->fediverse->init();
+
+		$this->assertNotFalse(
+			has_action(
+				'init',
+				array( $this->fediverse, 'maybe_load' )
+			),
+			'maybe_load action is missing'
+		);
+	}
+
+	/**
+	 * Test maybe_load does nothing when disabled by filter.
+	 *
+	 * @return void
+	 */
+	public function testMaybeLoad_WhenDisabledByFilter_ThenDoesNotRegisterRoutes() {
+		expect( 'apply_filters' )
+			->once()
+			->with( 'gravatar_enhanced_fediverse_module_enabled', true )
+			->andReturn( false );
+
+		expect( 'add_action' )->never();
+
+		$this->fediverse->maybe_load();
+	}
+
+	/**
+	 * Test maybe_load does nothing when option is disabled.
+	 *
+	 * @return void
+	 */
+	public function testMaybeLoad_WhenOptionDisabled_ThenDoesNotRegisterRoutes() {
+		expect( 'apply_filters' )
+			->once()
+			->with( 'gravatar_enhanced_fediverse_module_enabled', true )
+			->andReturn( true );
+
+		expect( 'get_option' )
+			->once()
+			->with( 'gravatar_fediverse_hovercards', true )
+			->andReturn( false );
+
+		expect( 'add_action' )->never();
+
+		$this->fediverse->maybe_load();
+	}
+
+	/**
+	 * Test maybe_load registers REST routes when enabled.
+	 *
+	 * @return void
+	 */
+	public function testMaybeLoad_WhenEnabled_ThenRegistersRestRoutes() {
+		expect( 'apply_filters' )
+			->once()
+			->with( 'gravatar_enhanced_fediverse_module_enabled', true )
+			->andReturn( true );
+
+		expect( 'get_option' )
+			->once()
+			->with( 'gravatar_fediverse_hovercards', true )
+			->andReturn( true );
+
+		expect( 'add_action' )
+			->once()
+			->with( 'rest_api_init', array( $this->fediverse, 'register_rest_routes' ) );
+
+		$this->fediverse->maybe_load();
+	}
+
+	/**
+	 * Test uninstall deletes the option.
+	 *
+	 * @return void
+	 */
+	public function testUninstall_WhenCalled_ThenDeletesOption() {
+		expect( 'delete_option' )
+			->once()
+			->with( 'gravatar_fediverse_hovercards' );
+
+		$this->fediverse->uninstall();
+	}
+
+	/**
+	 * Test REST namespace constant.
+	 *
+	 * @return void
+	 */
+	public function testRestRouteConstants_AreCorrect() {
+		$this->assertSame( 'gravatar-enhanced/v1', Fediverse::REST_NAMESPACE );
+		$this->assertSame( '/fediverse/lookup', Fediverse::REST_ROUTE_LOOKUP );
+	}
+
+	/**
+	 * Test filter constant.
+	 *
+	 * @return void
+	 */
+	public function testFilterConstants_AreCorrect() {
+		$this->assertSame( 'gravatar_enhanced_fediverse_module_enabled', Fediverse::FILTER_FEDIVERSE_MODULE_ENABLED );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const config = {
 		'wc-my-account': './src/woocommerce/my-account.ts',
 		'wc-admin-customers': './src/woocommerce/admin-customers.ts',
 		comments: './src/comments',
+		fediverse: './src/fediverse',
 		'patterns-shared': './classes/patterns/shared.scss',
 		'patterns-edit': './classes/patterns/edit.scss',
 		'patterns-view': './classes/patterns/view.scss',


### PR DESCRIPTION
## Description

Adds hovercard support for Fediverse profile URLs in comments. When hovering over a comment avatar whose author URL points to a Fediverse instance (e.g. Mastodon), the plugin now resolves the profile via WebFinger and ActivityPub actor JSON, then displays a lightweight hovercard with display name, summary, avatar, and follow link.

Closes #97

## Testing instructions

1. Enable the feature in Settings > Discussion (enabled by default)
2. Add a comment with a Fediverse profile URL (e.g. https://mastodon.social/@user)
3. Hover over the comment avatar
4. Verify the hovercard appears with profile data
5. Test with non-Fediverse URLs to confirm no hovercard appears
6. Verify existing Gravatar email hovercards still work unchanged

## Summary of changes

- **New REST endpoint:** `GET /wp-json/gravatar-enhanced/v1/fediverse/lookup?url=<fediverse-url>`
- **WebFinger resolution:** extracts Fediverse handle from various URL formats (`@user@instance`, `/users/user`, `/user`)
- **ActivityPub actor lookup:** fetches and normalizes actor JSON into display_name, summary, avatar, profile_url, follow_url
- **Settings toggle:** checkbox in Discussion settings (enabled by default)
- **Frontend hovercard:** lightweight custom UI on comment avatar hover
- **Transient caching:** 1-hour cache for lookup results